### PR TITLE
Address Hibernate Warnings

### DIFF
--- a/src/main/java/io/swagger/model/BrAPIDataModel.java
+++ b/src/main/java/io/swagger/model/BrAPIDataModel.java
@@ -2,24 +2,26 @@ package io.swagger.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 public abstract class BrAPIDataModel {
 
 	@JsonProperty("additionalInfo")
-	protected Object additionalInfo = null;
+	protected Map<String, Object> additionalInfo = null;
 
 	@JsonProperty("externalReferences")
 	protected ExternalReferences externalReferences = null;
 
-	final public BrAPIDataModel additionalInfo(Object additionalInfo) {
+	final public BrAPIDataModel additionalInfo(Map<String, Object>additionalInfo) {
 		this.additionalInfo = additionalInfo;
 		return this;
 	}
 
-	final public Object getAdditionalInfo() {
+	final public Map<String, Object>getAdditionalInfo() {
 		return additionalInfo;
 	}
 
-	final public void setAdditionalInfo(Object additionalInfo) {
+	final public void setAdditionalInfo(Map<String, Object>additionalInfo) {
 		this.additionalInfo = additionalInfo;
 	}
 	

--- a/src/main/java/io/swagger/model/core/BatchDeleteBaseFields.java
+++ b/src/main/java/io/swagger/model/core/BatchDeleteBaseFields.java
@@ -1,5 +1,6 @@
 package io.swagger.model.core;
 
+import java.util.Map;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
@@ -17,7 +18,7 @@ import jakarta.validation.Valid;
 public class BatchDeleteBaseFields implements BatchDeleteBaseFieldsInterface {
   @JsonProperty("additionalInfo")
   @Valid
-  private Object additionalInfo = null;
+  private Map<String, Object> additionalInfo = null;
 
   @JsonProperty("dateCreated")
   private OffsetDateTime dateCreated = null;
@@ -49,7 +50,7 @@ public class BatchDeleteBaseFields implements BatchDeleteBaseFieldsInterface {
   @JsonProperty("batchDeleteType")
   private BatchDeleteTypes batchDeleteType = null;
 
-  public BatchDeleteBaseFields additionalInfo(Object additionalInfo) {
+  public BatchDeleteBaseFields additionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
     return this;
   }
@@ -61,11 +62,11 @@ public class BatchDeleteBaseFields implements BatchDeleteBaseFieldsInterface {
    **/
   @ApiModelProperty(example = "{}", value = "Additional arbitrary info")
   
-    public Object getAdditionalInfo() {
+    public Map<String, Object>getAdditionalInfo() {
     return additionalInfo;
   }
 
-  public void setAdditionalInfo(Object additionalInfo) {
+  public void setAdditionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
   }
 

--- a/src/main/java/io/swagger/model/core/BatchDeleteBaseFieldsInterface.java
+++ b/src/main/java/io/swagger/model/core/BatchDeleteBaseFieldsInterface.java
@@ -1,16 +1,17 @@
 package io.swagger.model.core;
 
 import java.time.OffsetDateTime;
+import java.util.Map;
 
 import io.swagger.model.ExternalReferences;
 
 public interface BatchDeleteBaseFieldsInterface {
 
-	public BatchDeleteBaseFieldsInterface additionalInfo(Object additionalInfo);
+	public BatchDeleteBaseFieldsInterface additionalInfo(Map<String, Object> additionalInfo);
 
-	public Object getAdditionalInfo();
+	public Map<String, Object> getAdditionalInfo();
 
-	public void setAdditionalInfo(Object additionalInfo);
+	public void setAdditionalInfo(Map<String, Object> additionalInfo);
 
 	public BatchDeleteBaseFieldsInterface dateCreated(OffsetDateTime dateCreated);
 

--- a/src/main/java/io/swagger/model/core/ListBaseFields.java
+++ b/src/main/java/io/swagger/model/core/ListBaseFields.java
@@ -1,5 +1,6 @@
 package io.swagger.model.core;
 
+import java.util.Map;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
@@ -17,7 +18,7 @@ import jakarta.validation.Valid;
 public class ListBaseFields implements ListBaseFieldsInterface  {
   @JsonProperty("additionalInfo")
   @Valid
-  private Object additionalInfo = null;
+  private Map<String, Object> additionalInfo = null;
 
   @JsonProperty("dateCreated")
   private OffsetDateTime dateCreated = null;
@@ -49,7 +50,7 @@ public class ListBaseFields implements ListBaseFieldsInterface  {
   @JsonProperty("listType")
   private ListTypes listType = null;
 
-  public ListBaseFields additionalInfo(Object additionalInfo) {
+  public ListBaseFields additionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
     return this;
   }
@@ -61,11 +62,11 @@ public class ListBaseFields implements ListBaseFieldsInterface  {
    **/
   @ApiModelProperty(example = "{}", value = "Additional arbitrary info")
   
-    public Object getAdditionalInfo() {
+    public Map<String, Object>getAdditionalInfo() {
     return additionalInfo;
   }
 
-  public void setAdditionalInfo(Object additionalInfo) {
+  public void setAdditionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
   }
 

--- a/src/main/java/io/swagger/model/core/ListBaseFieldsInterface.java
+++ b/src/main/java/io/swagger/model/core/ListBaseFieldsInterface.java
@@ -1,16 +1,17 @@
 package io.swagger.model.core;
 
 import java.time.OffsetDateTime;
+import java.util.Map;
 
 import io.swagger.model.ExternalReferences;
 
 public interface ListBaseFieldsInterface {
 
-	public ListBaseFieldsInterface additionalInfo(Object additionalInfo);
+	public ListBaseFieldsInterface additionalInfo(Map<String, Object> additionalInfo);
 
-	public Object getAdditionalInfo();
+	public Map<String, Object> getAdditionalInfo();
 
-	public void setAdditionalInfo(Object additionalInfo);
+	public void setAdditionalInfo(Map<String, Object> additionalInfo);
 
 	public ListBaseFieldsInterface dateCreated(OffsetDateTime dateCreated);
 

--- a/src/main/java/io/swagger/model/core/PersonNewRequest.java
+++ b/src/main/java/io/swagger/model/core/PersonNewRequest.java
@@ -1,5 +1,6 @@
 package io.swagger.model.core;
 
+import java.util.Map;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -18,7 +19,7 @@ import jakarta.validation.Valid;
 public class PersonNewRequest   {
   @JsonProperty("additionalInfo")
   @Valid
-  private Object additionalInfo = null;
+  private Map<String, Object> additionalInfo = null;
 
   @JsonProperty("description")
   private String description = null;
@@ -47,7 +48,7 @@ public class PersonNewRequest   {
   @JsonProperty("userID")
   private String userID = null;
 
-  public PersonNewRequest additionalInfo(Object additionalInfo) {
+  public PersonNewRequest additionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
     return this;
   }
@@ -58,11 +59,11 @@ public class PersonNewRequest   {
   **/
   @ApiModelProperty(value = "Additional arbitrary info")
   
-    public Object getAdditionalInfo() {
+    public Map<String, Object>getAdditionalInfo() {
     return additionalInfo;
   }
 
-  public void setAdditionalInfo(Object additionalInfo) {
+  public void setAdditionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
   }
 

--- a/src/main/java/io/swagger/model/core/TrialNewRequest.java
+++ b/src/main/java/io/swagger/model/core/TrialNewRequest.java
@@ -1,5 +1,6 @@
 package io.swagger.model.core;
 
+import java.util.Map;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -24,7 +25,7 @@ public class TrialNewRequest   {
 
   @JsonProperty("additionalInfo")
   @Valid
-  private Object additionalInfo = null;
+  private Map<String, Object> additionalInfo = null;
 
   @JsonProperty("commonCropName")
   private String commonCropName = null;
@@ -87,7 +88,7 @@ public class TrialNewRequest   {
     this.active = active;
   }
 
-  public TrialNewRequest additionalInfo(Object additionalInfo) {
+  public TrialNewRequest additionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
     return this;
   }
@@ -98,11 +99,11 @@ public class TrialNewRequest   {
   **/
   @ApiModelProperty(value = "Additional arbitrary info")
   
-    public Object getAdditionalInfo() {
+    public Map<String, Object>getAdditionalInfo() {
     return additionalInfo;
   }
 
-  public void setAdditionalInfo(Object additionalInfo) {
+  public void setAdditionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
   }
 

--- a/src/main/java/io/swagger/model/geno/Call.java
+++ b/src/main/java/io/swagger/model/geno/Call.java
@@ -1,5 +1,6 @@
 package io.swagger.model.geno;
 
+import java.util.Map;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -8,7 +9,7 @@ import java.util.List;
 
 public class Call {
 	@JsonProperty("additionalInfo")
-	private Object additionalInfo = null;
+	private Map<String, Object> additionalInfo = null;
 
 	@JsonProperty("callSetDbId")
 	private String callSetDbId = null;
@@ -77,16 +78,16 @@ public class Call {
 		return this;
 	}
 	
-	public Call additionalInfo(Object additionalInfo) {
+	public Call additionalInfo(Map<String, Object> additionalInfo) {
 		this.additionalInfo = additionalInfo;
 		return this;
 	}
 
-	public Object getAdditionalInfo() {
+	public Map<String, Object> getAdditionalInfo() {
 		return additionalInfo;
 	}
 
-	public void setAdditionalInfo(Object additionalInfo) {
+	public void setAdditionalInfo(Map<String, Object> additionalInfo) {
 		this.additionalInfo = additionalInfo;
 	}
 

--- a/src/main/java/io/swagger/model/geno/SampleNewRequest.java
+++ b/src/main/java/io/swagger/model/geno/SampleNewRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import org.springframework.validation.annotation.Validated;
 
 import java.time.OffsetDateTime;
+import java.util.Map;
 import java.util.Objects;
 
 
@@ -18,7 +19,7 @@ import java.util.Objects;
 public class SampleNewRequest   {
   @JsonProperty("additionalInfo")
   @Valid
-  private Object additionalInfo = null;
+  private Map<String, Object> additionalInfo = null;
 
   @JsonProperty("column")
   private Integer column = null;
@@ -80,7 +81,7 @@ public class SampleNewRequest   {
   @JsonProperty("well")
   private String well = null;
 
-  public SampleNewRequest additionalInfo(Object additionalInfo) {
+  public SampleNewRequest additionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
     return this;
   }
@@ -91,11 +92,11 @@ public class SampleNewRequest   {
   **/
   @ApiModelProperty(value = "Additional arbitrary info")
   
-    public Object getAdditionalInfo() {
+    public Map<String, Object>getAdditionalInfo() {
     return additionalInfo;
   }
 
-  public void setAdditionalInfo(Object additionalInfo) {
+  public void setAdditionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
   }
 

--- a/src/main/java/io/swagger/model/geno/VendorSpecification.java
+++ b/src/main/java/io/swagger/model/geno/VendorSpecification.java
@@ -7,6 +7,7 @@ import org.springframework.validation.annotation.Validated;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -17,7 +18,7 @@ import java.util.Objects;
 public class VendorSpecification   {
   @JsonProperty("additionalInfo")
   @Valid
-  private Object additionalInfo = null;
+  private Map<String, Object> additionalInfo = null;
 
   @JsonProperty("services")
   @Valid
@@ -26,7 +27,7 @@ public class VendorSpecification   {
   @JsonProperty("vendorContact")
   private VendorContact vendorContact = null;
 
-  public VendorSpecification additionalInfo(Object additionalInfo) {
+  public VendorSpecification additionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
     return this;
   }
@@ -37,11 +38,11 @@ public class VendorSpecification   {
   **/
   @ApiModelProperty(value = "Additional arbitrary information specific to a particular Vendor. Look for the Vendors specific API documentation for more details")
   
-    public Object getAdditionalInfo() {
+    public Map<String, Object>getAdditionalInfo() {
     return additionalInfo;
   }
 
-  public void setAdditionalInfo(Object additionalInfo) {
+  public void setAdditionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
   }
 

--- a/src/main/java/io/swagger/model/germ/GermplasmAttributeValueNewRequest.java
+++ b/src/main/java/io/swagger/model/germ/GermplasmAttributeValueNewRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import org.springframework.validation.annotation.Validated;
 
 import java.time.OffsetDateTime;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -17,7 +18,7 @@ import java.util.Objects;
 public class GermplasmAttributeValueNewRequest {
 	@JsonProperty("additionalInfo")
 	@Valid
-	private Object additionalInfo = null;
+	private Map<String, Object> additionalInfo = null;
 
 	@JsonProperty("attributeDbId")
 	private String attributeDbId = null;
@@ -40,7 +41,7 @@ public class GermplasmAttributeValueNewRequest {
 	@JsonProperty("value")
 	private String value = null;
 
-	public GermplasmAttributeValueNewRequest additionalInfo(Object additionalInfo) {
+	public GermplasmAttributeValueNewRequest additionalInfo(Map<String, Object> additionalInfo) {
 		this.additionalInfo = additionalInfo;
 		return this;
 	}
@@ -52,11 +53,11 @@ public class GermplasmAttributeValueNewRequest {
 	 **/
 	@ApiModelProperty(value = "Additional arbitrary info")
 
-	public Object getAdditionalInfo() {
+	public Map<String, Object> getAdditionalInfo() {
 		return additionalInfo;
 	}
 
-	public void setAdditionalInfo(Object additionalInfo) {
+	public void setAdditionalInfo(Map<String, Object> additionalInfo) {
 		this.additionalInfo = additionalInfo;
 	}
 

--- a/src/main/java/io/swagger/model/pheno/ImageNewRequest.java
+++ b/src/main/java/io/swagger/model/pheno/ImageNewRequest.java
@@ -11,6 +11,7 @@ import org.springframework.validation.annotation.Validated;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 
@@ -22,7 +23,7 @@ import java.util.Objects;
 public class ImageNewRequest   {
   @JsonProperty("additionalInfo")
   @Valid
-  private Object additionalInfo = null;
+  private Map<String, Object> additionalInfo = null;
 
   @JsonProperty("copyright")
   private String copyright = null;
@@ -71,7 +72,7 @@ public class ImageNewRequest   {
   @JsonProperty("observationUnitDbId")
   private String observationUnitDbId = null;
 
-  public ImageNewRequest additionalInfo(Object additionalInfo) {
+  public ImageNewRequest additionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
     return this;
   }
@@ -81,12 +82,11 @@ public class ImageNewRequest   {
    * @return additionalInfo
   **/
   @ApiModelProperty(value = "")
-  
-    public Object getAdditionalInfo() {
+  public Map<String, Object> getAdditionalInfo() {
     return additionalInfo;
   }
 
-  public void setAdditionalInfo(Object additionalInfo) {
+  public void setAdditionalInfo(Map<String, Object> additionalInfo) {
     this.additionalInfo = additionalInfo;
   }
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/converter/JsonbConverter.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/converter/JsonbConverter.java
@@ -7,15 +7,16 @@ import org.slf4j.LoggerFactory;
 
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
+import java.util.Map;
 
 @Converter(autoApply = false)
-public class JsonbConverter implements AttributeConverter<Object, String> {
+public class JsonbConverter implements AttributeConverter<Map<String, Object>, String> {
 
     private final static ObjectMapper mapper = new ObjectMapper();
     private static final Logger log = LoggerFactory.getLogger(JsonbConverter.class);
 
     @Override
-    public String convertToDatabaseColumn(Object jsonb) {
+    public String convertToDatabaseColumn(Map<String, Object> jsonb) {
         try {
             return mapper.writeValueAsString(jsonb);
         } catch (JsonProcessingException e) {
@@ -24,12 +25,12 @@ public class JsonbConverter implements AttributeConverter<Object, String> {
     }
 
     @Override
-    public Object convertToEntityAttribute(String dbData) {
+    public Map<String, Object> convertToEntityAttribute(String dbData) {
         try {
             if (dbData == null) {
                 return null;
             }
-            return mapper.readValue(dbData, Object.class);
+            return mapper.readValue(dbData, Map.class);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/BrAPIPrimaryEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/BrAPIPrimaryEntity.java
@@ -7,6 +7,7 @@ import org.brapi.test.BrAPITestServer.converter.JsonbConverter;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @MappedSuperclass
 public class BrAPIPrimaryEntity extends BrAPIBaseEntity {
@@ -14,7 +15,7 @@ public class BrAPIPrimaryEntity extends BrAPIBaseEntity {
 
 	@Convert(converter= JsonbConverter.class)
 	@Column(columnDefinition="jsonb")
-	private Object additionalInfo;
+	private Map<String, Object> additionalInfo;
 
 	@ManyToMany(cascade = CascadeType.ALL)
 	@JoinTable(joinColumns = { @JoinColumn(referencedColumnName = "id") }, inverseJoinColumns = {
@@ -32,11 +33,11 @@ public class BrAPIPrimaryEntity extends BrAPIBaseEntity {
 		this.authUserId = authUserId;
 	}
 
-	public Object getAdditionalInfo() {
+	public Map<String, Object> getAdditionalInfo() {
 		return this.additionalInfo;
 	}
 
-	public void setAdditionalInfo(Object info) {
+	public void setAdditionalInfo(Map<String, Object> info) {
 		this.additionalInfo = info;
 	}
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/SeasonEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/SeasonEntity.java
@@ -9,7 +9,7 @@ import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
 @Entity
 @Table(name="season")
-public class SeasonEntity extends BrAPIPrimaryEntity{
+public class SeasonEntity extends BrAPIPrimaryEntity {
 	@Column
 	private String season;
 	@Column

--- a/src/main/resources/application.properties.template
+++ b/src/main/resources/application.properties.template
@@ -11,6 +11,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=false
+spring.jpa.open-in-view=true
 
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration,classpath:db/sql


### PR DESCRIPTION
These commits resolve two warnings.

One related to the use of Object serialization for the `additional_info` column of brapi objects, and another related to not setting the open in view.

The open in view setting is actually something we should try to address...I was not able to set it to false without a variety of problems coming about, but most resources on the internet do not recommend utilizing this feature set to true.  For now, I am setting it to true to resolve the warning.