### PR TITLE
Germplasm search optimizations

### DIFF
--- a/src/main/java/io/swagger/model/SearchRequest.java
+++ b/src/main/java/io/swagger/model/SearchRequest.java
@@ -2,6 +2,8 @@ package io.swagger.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.model.core.SortBy;
+import io.swagger.model.core.SortOrder;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/brapi/test/BrAPITestServer/controller/core/BrAPIController.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/controller/core/BrAPIController.java
@@ -11,7 +11,7 @@ import io.swagger.model.core.BatchDeletesListResponse;
 import io.swagger.model.core.BatchDeletesListResponseResult;
 import org.brapi.test.BrAPITestServer.auth.AuthDetails;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
-import org.brapi.test.BrAPITestServer.exceptions.InvalidPagingException;
+import org.brapi.test.BrAPITestServer.service.PagingUtility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -33,21 +33,6 @@ import io.swagger.model.TokenPagination;
 
 public class BrAPIController {
 	private static final Logger log = LoggerFactory.getLogger(ServerInfoApiController.class);
-	
-	protected Metadata generateMetaDataTemplateForSearch(Integer originalRequestedPage, Integer newRequestedPage,
-			Integer originalRequestedPageSize, Integer newRequestedPageSize) throws BrAPIServerException {
-		Integer page = newRequestedPage;
-		Integer pageSize = newRequestedPageSize;
-
-		if (page == null) {
-			page = originalRequestedPage;
-		}
-		if (pageSize == null) {
-			pageSize = originalRequestedPageSize;
-		}
-
-		return generateMetaDataTemplate(page, pageSize);
-	}
 
 	protected Metadata generateMetaDataTemplate(SearchRequest request) throws BrAPIServerException {
 		return generateMetaDataTemplate(request.getPage(), request.getPageSize());
@@ -55,7 +40,7 @@ public class BrAPIController {
 
 	protected Metadata generateMetaDataTemplate(String pageToken, Integer pageSize) {
 		if (pageSize == null) {
-			pageSize = 1000;
+			pageSize = PagingUtility.getDefaultPageSize();
 		}
 
 		Metadata metaData = generateEmptyMetadataToken();
@@ -65,30 +50,20 @@ public class BrAPIController {
 	}
 
 	protected Metadata generateMetaDataTemplate(Integer page, Integer pageSize) throws BrAPIServerException {
-		validatePaging(page, pageSize);
+		PagingUtility.validatePaging(page, pageSize);
 
 		// defaults
 		if (page == null) {
 			page = 0;
 		}
 		if (pageSize == null) {
-			pageSize = 1000;
+			pageSize = PagingUtility.getDefaultPageSize();
 		}
 
 		Metadata metaData = generateEmptyMetadata();
 		metaData.getPagination().setCurrentPage(page);
 		metaData.getPagination().setPageSize(pageSize);
 		return metaData;
-	}
-
-	private void validatePaging(Integer page, Integer pageSize) throws BrAPIServerException {
-		boolean pageValid = (page == null) || (page >= 0);
-		if (!pageValid)
-			throw new InvalidPagingException("page");
-		boolean pageSizeValid = (pageSize == null) || (pageSize >= 1);
-		if (!pageSizeValid)
-			throw new InvalidPagingException("pageSize");
-
 	}
 
 	protected Metadata generateEmptyMetadata() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/CrossesApiController.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/CrossesApiController.java
@@ -59,8 +59,8 @@ public class CrossesApiController extends BrAPIController implements CrossesApi 
 		validateSecurityContext(request, "ROLE_ANONYMOUS", "ROLE_USER");
 		validateAcceptHeader(request);
 		Metadata metadata = generateMetaDataTemplate(page, pageSize);
-		List<Cross> data = crossService.findCrosses(crossingProjectDbId, crossingProjectName, crossDbId, crossName,
-				commonCropName, programDbId, externalReferenceId, externalReferenceID, externalReferenceSource,
+		List<Cross> data = crossService.findCrosses(crossingProjectDbId, crossDbId,
+				externalReferenceID, externalReferenceSource,
 				metadata);
 		return responseOK(new CrossesListResponse(), new CrossesListResponseResult(), data, metadata);
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/CrossingProjectsApiController.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/CrossingProjectsApiController.java
@@ -60,8 +60,8 @@ public class CrossingProjectsApiController extends BrAPIController implements Cr
 		validateAcceptHeader(request);
 		Metadata metadata = generateMetaDataTemplate(page, pageSize);
 		List<CrossingProject> data = crossingProjectService.findCrossingProjects(crossingProjectDbId,
-				crossingProjectName, includePotentialParents, commonCropName, programDbId, externalReferenceId,
-				externalReferenceID, externalReferenceSource, metadata);
+				crossingProjectName, includePotentialParents, commonCropName, programDbId,
+                externalReferenceID, externalReferenceSource, metadata);
 		return responseOK(new CrossingProjectsListResponse(), new CrossingProjectsListResponseResult(), data, metadata);
 	}
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/GermplasmApiController.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/GermplasmApiController.java
@@ -191,12 +191,37 @@ public class GermplasmApiController extends BrAPIController implements Germplasm
 		log.debug("Request: " + request.getRequestURI());
 		validateSecurityContext(request, "ROLE_ANONYMOUS", "ROLE_USER");
 		validateAcceptHeader(request);
-		Metadata metadata = generateMetaDataTemplate(body);
 
 		String searchReqDbId = searchService.saveSearchRequest(body, SearchRequestTypes.GERMPLASM);
 		if (searchReqDbId != null) {
 			return responseAccepted(searchReqDbId);
+		}
+
+		// WARN: This code was introduced to deal with a specific use case from BI which requires all data associated with
+		// a particular program to be retreived at once.  This method of data retreival is highly unadvised and can come
+		// with serious performance deficits, such as slow response times and exhausted memory allocation.
+		// Benchmarking suggests that at around 245-275k germplasm records returned 8GB of allocated memory will fail to
+		// be enough to return a result.
+
+		// This code is a stop-gap to allow BI to continue to do this improper retreival in a way that will be efficient
+		// for their specific use case.
+
+		// To get the data in this ill-advised way, forgo sending a page or pageSize attribute in the germplasm search request
+		// to this endpoint.  This will trigger the findGermplasmWithoutPaging code, which will grab all of the data without regard
+		// to data size.
+
+		// To use the endpoint the right way, ensure one or both of the aforementioned attributes are set and the germplasm
+		// records will be retrieved and returned paginated to limit resource consumption.  This way is much more fine tuned
+		// and will result in fast retrieval times with minimal memory allocation.
+		if (body.getPage() == null && body.getPageSize() == null) {
+			log.debug("Retrieving germs without pagination");
+			List<Germplasm> data = germplasmService.findGermplasmWithoutPaging(body);
+			Metadata metadata = generateEmptyMetadata();
+			metadata.getPagination().setTotalCount(data.size());
+			return responseOK(new GermplasmListResponse(), new GermplasmListResponseResult(), data, metadata);
 		} else {
+			log.debug("Retrieving germs with pagination");
+			Metadata metadata = generateMetaDataTemplate(body);
 			List<Germplasm> data = germplasmService.findGermplasm(body, metadata);
 			return responseOK(new GermplasmListResponse(), new GermplasmListResponseResult(), data, metadata);
 		}

--- a/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/PlannedCrossesApiController.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/PlannedCrossesApiController.java
@@ -60,8 +60,8 @@ public class PlannedCrossesApiController extends BrAPIController implements Plan
 		validateSecurityContext(request, "ROLE_ANONYMOUS", "ROLE_USER");
 		validateAcceptHeader(request);
 		Metadata metadata = generateMetaDataTemplate(page, pageSize);
-		List<PlannedCross> data = crossService.findPlannedCrosses(crossingProjectDbId, crossingProjectName,
-				plannedCrossDbId, plannedCrossName, status, commonCropName, programDbId, externalReferenceId,
+		List<PlannedCross> data = crossService.findPlannedCrosses(crossingProjectDbId,
+				plannedCrossDbId,
 				externalReferenceID, externalReferenceSource, metadata);
 		return responseOK(new PlannedCrossesListResponse(), new PlannedCrossesListResponseResult(), data, metadata);
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/SeedLotsApiController.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/SeedLotsApiController.java
@@ -66,7 +66,7 @@ public class SeedLotsApiController extends BrAPIController implements SeedLotsAp
 		validateAcceptHeader(request);
 		Metadata metadata = generateMetaDataTemplate(page, pageSize);
 		List<SeedLot> data = seedLotService.findSeedLots(seedLotDbId, germplasmDbId, germplasmName, crossDbId,
-				crossName, commonCropName, programDbId, externalReferenceId, externalReferenceID,
+				crossName, commonCropName, programDbId, externalReferenceID,
 				externalReferenceSource, metadata);
 		return responseOK(new SeedLotListResponse(), new SeedLotListResponseResult(), data, metadata);
 	}
@@ -156,7 +156,7 @@ public class SeedLotsApiController extends BrAPIController implements SeedLotsAp
 		validateAcceptHeader(request);
 		Metadata metadata = generateMetaDataTemplate(page, pageSize);
 		List<SeedLotTransaction> data = seedLotService.findSeedLotTransactions(transactionDbId, seedLotDbId,
-				germplasmDbId, germplasmName, crossDbId, crossName, commonCropName, programDbId, externalReferenceId,
+				germplasmDbId, germplasmName, crossDbId, crossName, commonCropName, programDbId,
 				externalReferenceID, externalReferenceSource, metadata);
 		return responseOK(new SeedLotTransactionListResponse(), new SeedLotTransactionListResponseResult(), data,
 				metadata);

--- a/src/main/java/org/brapi/test/BrAPITestServer/converter/JsonbConverter.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/converter/JsonbConverter.java
@@ -17,7 +17,10 @@ public class JsonbConverter implements AttributeConverter<Object, String> {
     @Override
     public String convertToDatabaseColumn(Object jsonb) {
         try {
-            return mapper.writeValueAsString(jsonb);
+            if (jsonb != null) {
+                return mapper.writeValueAsString(jsonb);
+            }
+            return null;
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/org/brapi/test/BrAPITestServer/exceptions/InvalidPagingException.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/exceptions/InvalidPagingException.java
@@ -4,9 +4,18 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidPagingException extends BrAPIServerException {
 	private static final long serialVersionUID = 6250184179200451757L;
+
+	private static final String pageNumExceedsTotalPages =
+			"A page was requested which exceeds total amount of data available. Please make a RQ with page < totalPages - 1. " +
+					"Page numbers start at 0, and you can find out totalPages by making a RQ with \"page\": 0";
 		
 	public InvalidPagingException(String field) {
 		super(HttpStatus.BAD_REQUEST, "\'" + field + "\' value is invalid");
+	}
+
+	// This constructor should only be used when the pageNum of the RQ exceeds the total number of pages available.
+	public InvalidPagingException() {
+		super(HttpStatus.BAD_REQUEST, pageNumExceedsTotalPages);
 	}
 	
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/factory/BrAPIComponent.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/factory/BrAPIComponent.java
@@ -4,11 +4,12 @@ import io.swagger.model.Metadata;
 import io.swagger.model.SearchRequest;
 import io.swagger.model.core.BatchDeleteTypes;
 import jakarta.validation.Valid;
+import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
 
 import java.util.List;
 
 public interface BrAPIComponent<T, R extends SearchRequest> {
-    List<T> findEntities(@Valid R request, Metadata metadata);
+    List<T> findEntities(@Valid R request, Metadata metadata) throws BrAPIServerException;
     BatchDeleteTypes getBatchDeleteType();
     List<String> collectDbIds(List<T> entities);
     void deleteBatchDeleteData(List<String> dbIds);

--- a/src/main/java/org/brapi/test/BrAPITestServer/factory/core/ListComponent.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/factory/core/ListComponent.java
@@ -5,6 +5,7 @@ import io.swagger.model.core.BatchDeleteTypes;
 import io.swagger.model.core.ListSearchRequest;
 import io.swagger.model.core.ListSummary;
 import jakarta.validation.Valid;
+import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
 import org.brapi.test.BrAPITestServer.factory.BrAPIComponent;
 import org.brapi.test.BrAPITestServer.service.core.ListService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +24,8 @@ public class ListComponent implements BrAPIComponent<ListSummary, ListSearchRequ
     }
 
     @Override
-    public List<ListSummary> findEntities(@Valid ListSearchRequest request, Metadata metadata) {
+    public List<ListSummary> findEntities(@Valid ListSearchRequest request, Metadata metadata)
+        throws BrAPIServerException {
         return listService.findLists(request, metadata);
     }
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/factory/core/TrialComponent.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/factory/core/TrialComponent.java
@@ -4,6 +4,7 @@ import io.swagger.model.Metadata;
 import io.swagger.model.core.BatchDeleteTypes;
 import io.swagger.model.core.Trial;
 import io.swagger.model.core.TrialSearchRequest;
+import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
 import org.brapi.test.BrAPITestServer.factory.BrAPIComponent;
 import org.brapi.test.BrAPITestServer.service.core.TrialService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +23,8 @@ public class TrialComponent implements BrAPIComponent<Trial, TrialSearchRequest>
     }
 
     @Override
-    public List<Trial> findEntities(TrialSearchRequest request, Metadata metadata) {
+    public List<Trial> findEntities(TrialSearchRequest request, Metadata metadata)
+        throws BrAPIServerException {
         return trialService.findTrials(request, metadata);
     }
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/factory/geno/SampleComponent.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/factory/geno/SampleComponent.java
@@ -4,6 +4,7 @@ import io.swagger.model.Metadata;
 import io.swagger.model.core.BatchDeleteTypes;
 import io.swagger.model.geno.Sample;
 import io.swagger.model.geno.SampleSearchRequest;
+import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
 import org.brapi.test.BrAPITestServer.factory.BrAPIComponent;
 import org.brapi.test.BrAPITestServer.service.geno.SampleService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +23,8 @@ public class SampleComponent implements BrAPIComponent<Sample, SampleSearchReque
     }
 
     @Override
-    public List<Sample> findEntities(SampleSearchRequest request, Metadata metadata) {
+    public List<Sample> findEntities(SampleSearchRequest request, Metadata metadata)
+        throws BrAPIServerException {
         return sampleService.findSamples(request, metadata);
     }
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/factory/germ/GermplasmComponent.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/factory/germ/GermplasmComponent.java
@@ -5,6 +5,7 @@ import io.swagger.model.core.BatchDeleteTypes;
 import io.swagger.model.germ.Germplasm;
 import io.swagger.model.germ.GermplasmSearchRequest;
 import jakarta.validation.Valid;
+import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
 import org.brapi.test.BrAPITestServer.factory.BrAPIComponent;
 import org.brapi.test.BrAPITestServer.service.germ.GermplasmService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +24,8 @@ public class GermplasmComponent implements BrAPIComponent<Germplasm, GermplasmSe
     }
 
     @Override
-    public List<Germplasm> findEntities(@Valid GermplasmSearchRequest request, Metadata metadata) {
+    public List<Germplasm> findEntities(@Valid GermplasmSearchRequest request, Metadata metadata)
+        throws BrAPIServerException {
         return germplasmService.findGermplasm(request, metadata);
     }
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepository.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepository.java
@@ -3,8 +3,8 @@ package org.brapi.test.BrAPITestServer.repository;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
+import org.brapi.test.BrAPITestServer.exceptions.InvalidPagingException;
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.service.SearchQueryBuilder;
 import org.springframework.data.domain.Page;
@@ -15,9 +15,9 @@ import org.springframework.data.repository.NoRepositoryBean;
 @NoRepositoryBean
 public interface BrAPIRepository<T extends BrAPIPrimaryEntity, ID extends Serializable> extends JpaRepository<T, ID> {
 
-	public Page<T> findAllBySearchAndPaginate(SearchQueryBuilder<T> searchQuery, Pageable pageReq);
+	public Page<T> findAllBySearchAndPaginate(SearchQueryBuilder<T> searchQuery, Pageable pageReq) throws InvalidPagingException;
 
-	public Page<T> findAllBySearchPaginatingWithFetches(SearchQueryBuilder<T> searchQuery, Pageable pageReq);
+	public Page<T> findAllBySearchPaginatingWithFetches(SearchQueryBuilder<T> searchQuery, Pageable pageReq) throws InvalidPagingException;
 
 	public List<T> findAllBySearch(SearchQueryBuilder<T> searchQuery);
 
@@ -29,5 +29,5 @@ public interface BrAPIRepository<T extends BrAPIPrimaryEntity, ID extends Serial
 	
 	public <S extends T> void refresh(S entity);
 
-	public void fetchXrefs(Page<T> page, Class<T> searchClass);
+	public void fetchXrefs(Page<T> page, Class<T> searchClass) throws InvalidPagingException;
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepository.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepository.java
@@ -3,6 +3,7 @@ package org.brapi.test.BrAPITestServer.repository;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.service.SearchQueryBuilder;
@@ -15,6 +16,10 @@ import org.springframework.data.repository.NoRepositoryBean;
 public interface BrAPIRepository<T extends BrAPIPrimaryEntity, ID extends Serializable> extends JpaRepository<T, ID> {
 
 	public Page<T> findAllBySearch(SearchQueryBuilder<T> searchQuery, Pageable pageReq);
+
+	public Page<UUID> findAllBySearchIdsOnly(SearchQueryBuilder<T> searchQuery, Pageable pageReq);
+
+	public Page<T> findAllBySearchNoPage(SearchQueryBuilder<T> searchQuery, Page<UUID> pagedIds, Pageable pageReq);
 
 	public Optional<T> findById(ID id);
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepository.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepository.java
@@ -15,11 +15,11 @@ import org.springframework.data.repository.NoRepositoryBean;
 @NoRepositoryBean
 public interface BrAPIRepository<T extends BrAPIPrimaryEntity, ID extends Serializable> extends JpaRepository<T, ID> {
 
-	public Page<T> findAllBySearch(SearchQueryBuilder<T> searchQuery, Pageable pageReq);
+	public Page<T> findAllBySearchAndPaginate(SearchQueryBuilder<T> searchQuery, Pageable pageReq);
 
-	public Page<UUID> findAllBySearchIdsOnly(SearchQueryBuilder<T> searchQuery, Pageable pageReq);
+	public Page<T> findAllBySearchPaginatingWithFetches(SearchQueryBuilder<T> searchQuery, Pageable pageReq);
 
-	public Page<T> findAllBySearchNoPage(SearchQueryBuilder<T> searchQuery, Page<UUID> pagedIds, Pageable pageReq);
+	public List<T> findAllBySearch(SearchQueryBuilder<T> searchQuery);
 
 	public Optional<T> findById(ID id);
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepositoryImpl.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepositoryImpl.java
@@ -4,6 +4,7 @@ import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.ExternalReferenceEntity;
 import org.brapi.test.BrAPITestServer.service.SearchQueryBuilder;
+import org.brapi.test.BrAPITestServer.service.SecurityUtils;
 import org.hibernate.jpa.QueryHints;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -44,7 +45,7 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 	public Page<T> findAllBySearchNoPage(SearchQueryBuilder<T> searchQuery, Page<UUID> pagedIds, Pageable pageReq) {
 		applyUserId(searchQuery);
 
-		var entities = searchEntitiesWithIds(searchQuery, pagedIds);
+		List<T> entities = searchEntitiesWithIds(searchQuery, pagedIds);
 
 		return new PageImpl<>(entities, pageReq, pagedIds.getTotalElements());
 	}
@@ -66,7 +67,7 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 	public Optional<T> findById(ID id) {
 		Optional<T> response = super.findById(id);
 		if (response.isPresent()) {
-			String userId = getCurrentUserId();
+			String userId = SecurityUtils.getCurrentUserId();
 			if (!(null == response.get().getAuthUserId()
 					|| userId.equals(response.get().getAuthUserId())
 					|| "anonymousUser".equals(response.get().getAuthUserId()))) {
@@ -77,13 +78,13 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 	}
 
 	public <S extends T> S save(S entity) {
-		entity.setAuthUserId(getCurrentUserId());
+		entity.setAuthUserId(SecurityUtils.getCurrentUserId());
 		return super.save(entity);
 	}
 
 	public <S extends T> List<S> saveAll(Iterable<S> entities) {
 		for (S entity : entities) {
-			entity.setAuthUserId(getCurrentUserId());
+			entity.setAuthUserId(SecurityUtils.getCurrentUserId());
 		}
 		return super.saveAll(entities);
 	}
@@ -112,7 +113,7 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 				.map(auth -> auth.getAuthority()).collect(Collectors.toSet());
 
 		List<String> userIds = new ArrayList<>();
-		userIds.add(getCurrentUserId());
+		userIds.add(SecurityUtils.getCurrentUserId());
 		if (userRolesSet.contains("ROLE_ADMIN")) {
 			return;
 		} else if (userRolesSet.contains("ROLE_USER")) {
@@ -138,7 +139,7 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 	}
 
 	private List<T> searchEntitiesWithIds(SearchQueryBuilder<T> searchQuery, Page<UUID> ids) {
-		searchQuery.appendList(ids.stream().map(UUID::toString).toList(), "id");
+		searchQuery.appendList(ids.stream().map(UUID::toString).collect(Collectors.toList()), "id");
 
 		TypedQuery<T> query = entityManager.createQuery(searchQuery.getQuery(), searchQuery.getClazz());
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepositoryImpl.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepositoryImpl.java
@@ -65,10 +65,10 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 		applyUserId(searchQuery);
 
 		// First grab all the ids of the entities according to the criteria of the searchQuery, paging as specified in the pageReq.
-		List<UUID> content = getPagedContentIdsOnly(searchQuery, pageReq);
+		List<String> content = getPagedContentIdsOnly(searchQuery, pageReq);
 		Long totalCount = getTotalCount(searchQuery);
 
-		Page<UUID> pagedIds = new PageImpl<>(content, pageReq, totalCount);
+		Page<String> pagedIds = new PageImpl<>(content, pageReq, totalCount);
 
 		// Now execute another query to fetch all the entities requested in the searchQuery, passing the pagedIds found
 		// in the previous query.  We will fetch them utilizing the ids from the paged query, avoiding the hibernate
@@ -76,10 +76,10 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
         return findAllBySearchUsingIds(searchQuery, pagedIds, pageReq);
 	}
 
-	private Page<T> findAllBySearchUsingIds(SearchQueryBuilder<T> searchQuery, Page<UUID> pagedIds, Pageable pageReq) {
+	private Page<T> findAllBySearchUsingIds(SearchQueryBuilder<T> searchQuery, Page<String> pagedIds, Pageable pageReq) {
 		List<T> entities = searchEntitiesWithIds(searchQuery, pagedIds.toList());
 
-		return new PageImpl<>(entities, pageReq, pagedIds.getSize());
+		return new PageImpl<>(entities, pageReq, pagedIds.getTotalElements());
 	}
 
 	/**
@@ -162,7 +162,7 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
         return query.getResultList();
 	}
 
-	private List<T> searchEntitiesWithIds(SearchQueryBuilder<T> searchQuery, List<UUID> ids) {
+	private List<T> searchEntitiesWithIds(SearchQueryBuilder<T> searchQuery, List<String> ids) {
 		searchQuery.appendList(ids.stream().map(Object::toString).collect(Collectors.toList()), "id");
 
 		TypedQuery<T> query = entityManager.createQuery(searchQuery.getQuery(), searchQuery.getClazz());
@@ -186,9 +186,9 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 		}
 	}
 
-	private List<UUID> getPagedContentIdsOnly(SearchQueryBuilder<T> searchQuery, Pageable pageReq) {
+	private List<String> getPagedContentIdsOnly(SearchQueryBuilder<T> searchQuery, Pageable pageReq) {
 
-		TypedQuery<UUID> query = entityManager.createQuery(searchQuery.getIdQuery(), UUID.class);
+		TypedQuery<String> query = entityManager.createQuery(searchQuery.getIdQuery(), String.class);
 
 		for (Entry<String, Object> entry : searchQuery.getParams().entrySet()) {
 			query.setParameter(entry.getKey(), entry.getValue());

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepositoryImpl.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepositoryImpl.java
@@ -1,5 +1,15 @@
 package org.brapi.test.BrAPITestServer.repository;
 
+import java.io.Serializable;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import io.swagger.model.Metadata;
+import io.swagger.model.germ.GermplasmSearchRequest;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.ExternalReferenceEntity;
@@ -15,53 +25,70 @@ import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-import java.io.Serializable;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
-
 public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serializable>
 		extends SimpleJpaRepository<T, ID> implements BrAPIRepository<T, ID> {
-	private EntityManager entityManager;
+	private final EntityManager entityManager;
 
 	public BrAPIRepositoryImpl(JpaEntityInformation<T, ID> entityInformation, EntityManager entityManager) {
 		super(entityInformation, entityManager);
 		this.entityManager = entityManager;
 	}
 
-	// This is the method that should be used for simple entities with few collections and eager loading requirements.
-	public Page<T> findAllBySearch(SearchQueryBuilder<T> searchQuery, Pageable pageReq) {
+	/**
+	 * 	Use this method to page simple entities with no lazily loaded collections or attributes.
+	 * 	WARN: Failure to do so can easily exhaust memory at scale and will cause hibernate warnings.
+	 */
+	public Page<T> findAllBySearchAndPaginate(SearchQueryBuilder<T> searchQuery, Pageable pageReq) {
 		applyUserId(searchQuery);
 		List<T> content = getPagedContent(searchQuery, pageReq);
 		Long totalCount = getTotalCount(searchQuery);
 
-		Page<T> page = new PageImpl<>(content, pageReq, totalCount);
-
-		return page;
+        return new PageImpl<>(content, pageReq, totalCount);
 	}
 
-	public Page<T> findAllBySearchNoPage(SearchQueryBuilder<T> searchQuery, Page<UUID> pagedIds, Pageable pageReq) {
+	/**
+	 * This method should be used when there is a need to page entities that are complex and have lots of lazily loaded,
+	 * one-to-many collection attributes. Call this method with the query you've built.
+	 * WARN: To avoid multiple bag fetch hibernate errors, only one collection that is one-many can be fetched at a time.
+	 * Ensure only one of these types of entity members is being fetched at time.
+	 * See {@link org.brapi.test.BrAPITestServer.service.germ.GermplasmService#findGermplasmEntities(GermplasmSearchRequest, Metadata)} for example usage.
+	 *
+	 * Once you fetch the first lazy loaded collection, if there are others you need to fetch for your entity it is
+	 * recommended to utilize the non-paging findAllBySearch() method, creating a searchQuery that inserts all the ids
+	 * of the entities found in the results from this method.  Again, follow code path of above example usage to see how this is done.
+	 *
+	 * If the need is to fetch according to an entirely different base criteria, feel free to call this method again.
+	 *
+	 * The results will be paged and ordered based on the submitted searchQuery and pageReq.
+    */
+	public Page<T> findAllBySearchPaginatingWithFetches(SearchQueryBuilder<T> searchQuery, Pageable pageReq) {
 		applyUserId(searchQuery);
 
-		List<T> entities = searchEntitiesWithIds(searchQuery, pagedIds);
-
-		return new PageImpl<>(entities, pageReq, pagedIds.getTotalElements());
-	}
-
-
-
-	// For entities that are complex and have lots of Collections and lazy loaded entities, it is more efficient to grab the IDs of the on Page,
-	// and afterward fetch these collections using the Ids, this time without paging.
-	public Page<UUID> findAllBySearchIdsOnly(SearchQueryBuilder<T> searchQuery, Pageable pageReq) {
-		applyUserId(searchQuery);
+		// First grab all the ids of the entities according to the criteria of the searchQuery, paging as specified in the pageReq.
 		List<UUID> content = getPagedContentIdsOnly(searchQuery, pageReq);
 		Long totalCount = getTotalCount(searchQuery);
 
-		Page<UUID> page = new PageImpl<>(content, pageReq, totalCount);
+		Page<UUID> pagedIds = new PageImpl<>(content, pageReq, totalCount);
 
-		return page;
+		// Now execute another query to fetch all the entities requested in the searchQuery, passing the pagedIds found
+		// in the previous query.  We will fetch them utilizing the ids from the paged query, avoiding the hibernate
+		// warning of paging while fetching and consuming considerably less memory.
+        return findAllBySearchUsingIds(searchQuery, pagedIds, pageReq);
+	}
+
+	private Page<T> findAllBySearchUsingIds(SearchQueryBuilder<T> searchQuery, Page<UUID> pagedIds, Pageable pageReq) {
+		List<T> entities = searchEntitiesWithIds(searchQuery, pagedIds.toList());
+
+		return new PageImpl<>(entities, pageReq, pagedIds.getSize());
+	}
+
+	/**
+	 * Use this method to run the searchQuery without pagination.  Useful for use cases where calls need to grab
+	 * every result at once, but use sparingly for use cases returning large result sets.
+	 */
+	public List<T> findAllBySearch(SearchQueryBuilder<T> searchQuery) {
+		applyUserId(searchQuery);
+		return searchEntities(searchQuery);
 	}
 
 	public Optional<T> findById(ID id) {
@@ -98,7 +125,7 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 		searchQuery.leftJoinFetch("externalReferences", "externalReferences")
 				   .appendList(page.stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()), "id");
 
-		Page<T> xrefs = findAllBySearch(searchQuery, PageRequest.of(0, page.getSize()));
+		Page<T> xrefs = findAllBySearchAndPaginate(searchQuery, PageRequest.of(0, page.getSize()));
 
 		Map<String, List<ExternalReferenceEntity>> xrefByEntity = new HashMap<>();
 		xrefs.forEach(entity -> xrefByEntity.put(entity.getId(), entity.getExternalReferences()));
@@ -127,28 +154,37 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 		TypedQuery<T> query = entityManager.createQuery(searchQuery.getQuery(), searchQuery.getClazz());
 		query.setHint(QueryHints.HINT_PASS_DISTINCT_THROUGH, false);
 
-		for (Entry<String, Object> entry : searchQuery.getParams().entrySet()) {
-			query.setParameter(entry.getKey(), entry.getValue());
-		}
+		setQueryParams(query, searchQuery);
 
 		query.setFirstResult((int) pageReq.getOffset());
 		query.setMaxResults(pageReq.getPageSize());
 
-		List<T> content = query.getResultList();
-		return content;
+        return query.getResultList();
 	}
 
-	private List<T> searchEntitiesWithIds(SearchQueryBuilder<T> searchQuery, Page<UUID> ids) {
-		searchQuery.appendList(ids.stream().map(UUID::toString).collect(Collectors.toList()), "id");
+	private List<T> searchEntitiesWithIds(SearchQueryBuilder<T> searchQuery, List<UUID> ids) {
+		searchQuery.appendList(ids.stream().map(Object::toString).collect(Collectors.toList()), "id");
 
 		TypedQuery<T> query = entityManager.createQuery(searchQuery.getQuery(), searchQuery.getClazz());
 
+		setQueryParams(query, searchQuery);
+
+        return query.getResultList();
+	}
+
+	private List<T> searchEntities(SearchQueryBuilder<T> searchQuery) {
+		TypedQuery<T> query = entityManager.createQuery(searchQuery.getQuery(), searchQuery.getClazz());
+
+		setQueryParams(query, searchQuery);
+
+		return query.getResultList();
+	}
+
+	private void setQueryParams(TypedQuery<T> query, SearchQueryBuilder<T> searchQuery) {
 		for (Entry<String, Object> entry : searchQuery.getParams().entrySet()) {
 			query.setParameter(entry.getKey(), entry.getValue());
 		}
-
-		List<T> content = query.getResultList();
-		return content;	}
+	}
 
 	private List<UUID> getPagedContentIdsOnly(SearchQueryBuilder<T> searchQuery, Pageable pageReq) {
 
@@ -161,8 +197,7 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 		query.setFirstResult((int) pageReq.getOffset());
 		query.setMaxResults(pageReq.getPageSize());
 
-		List<UUID> content = query.getResultList();
-		return content;
+        return query.getResultList();
 	}
 
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepositoryImpl.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepositoryImpl.java
@@ -30,12 +30,35 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 		this.entityManager = entityManager;
 	}
 
+	// This is the method that should be used for simple entities with few collections and eager loading requirements.
 	public Page<T> findAllBySearch(SearchQueryBuilder<T> searchQuery, Pageable pageReq) {
-		searchQuery = applyUserId(searchQuery);
+		applyUserId(searchQuery);
 		List<T> content = getPagedContent(searchQuery, pageReq);
 		Long totalCount = getTotalCount(searchQuery);
 
 		Page<T> page = new PageImpl<>(content, pageReq, totalCount);
+
+		return page;
+	}
+
+	public Page<T> findAllBySearchNoPage(SearchQueryBuilder<T> searchQuery, Page<UUID> pagedIds, Pageable pageReq) {
+		applyUserId(searchQuery);
+
+		var entities = searchEntitiesWithIds(searchQuery, pagedIds);
+
+		return new PageImpl<>(entities, pageReq, pagedIds.getTotalElements());
+	}
+
+
+
+	// For entities that are complex and have lots of Collections and lazy loaded entities, it is more efficient to grab the IDs of the on Page,
+	// and afterward fetch these collections using the Ids, this time without paging.
+	public Page<UUID> findAllBySearchIdsOnly(SearchQueryBuilder<T> searchQuery, Pageable pageReq) {
+		applyUserId(searchQuery);
+		List<UUID> content = getPagedContentIdsOnly(searchQuery, pageReq);
+		Long totalCount = getTotalCount(searchQuery);
+
+		Page<UUID> page = new PageImpl<>(content, pageReq, totalCount);
 
 		return page;
 	}
@@ -82,16 +105,7 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 		page.forEach(entity -> entity.setExternalReferences(xrefByEntity.get(entity.getId())));
 	}
 
-	private String getCurrentUserId() {
-		SecurityContext context = SecurityContextHolder.getContext();
-		String userId = "";
-		if (context.getAuthentication().getPrincipal() != null) {
-			userId = context.getAuthentication().getPrincipal().toString();
-		}
-		return userId;
-	}
-
-	private SearchQueryBuilder<T> applyUserId(SearchQueryBuilder<T> searchQuery) {
+	private void applyUserId(SearchQueryBuilder<T> searchQuery) {
 
 		SecurityContext context = SecurityContextHolder.getContext();
 		Set<String> userRolesSet = context.getAuthentication().getAuthorities().stream()
@@ -100,14 +114,12 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 		List<String> userIds = new ArrayList<>();
 		userIds.add(getCurrentUserId());
 		if (userRolesSet.contains("ROLE_ADMIN")) {
-			return searchQuery;
+			return;
 		} else if (userRolesSet.contains("ROLE_USER")) {
 			userIds.add("anonymousUser");
 		}
 
 		searchQuery.appendList(userIds, "authUserId");
-
-		return searchQuery;
 	}
 
 	private List<T> getPagedContent(SearchQueryBuilder<T> searchQuery, Pageable pageReq) {
@@ -124,6 +136,36 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 		List<T> content = query.getResultList();
 		return content;
 	}
+
+	private List<T> searchEntitiesWithIds(SearchQueryBuilder<T> searchQuery, Page<UUID> ids) {
+		searchQuery.appendList(ids.stream().map(UUID::toString).toList(), "id");
+
+		TypedQuery<T> query = entityManager.createQuery(searchQuery.getQuery(), searchQuery.getClazz());
+
+		for (Entry<String, Object> entry : searchQuery.getParams().entrySet()) {
+			query.setParameter(entry.getKey(), entry.getValue());
+		}
+
+		List<T> content = query.getResultList();
+		return content;	}
+
+	private List<UUID> getPagedContentIdsOnly(SearchQueryBuilder<T> searchQuery, Pageable pageReq) {
+
+		TypedQuery<UUID> query = entityManager.createQuery(searchQuery.getIdQuery(), UUID.class);
+
+		for (Entry<String, Object> entry : searchQuery.getParams().entrySet()) {
+			query.setParameter(entry.getKey(), entry.getValue());
+		}
+
+		query.setFirstResult((int) pageReq.getOffset());
+		query.setMaxResults(pageReq.getPageSize());
+
+		List<UUID> content = query.getResultList();
+		return content;
+	}
+
+
+
 
 	private Long getTotalCount(SearchQueryBuilder<T> searchQuery) {
 		String countQueryStr = searchQuery.getQuery()

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepositoryImpl.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepositoryImpl.java
@@ -10,6 +10,7 @@ import io.swagger.model.germ.GermplasmSearchRequest;
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
 
+import org.brapi.test.BrAPITestServer.exceptions.InvalidPagingException;
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.ExternalReferenceEntity;
@@ -38,10 +39,20 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 	 * 	Use this method to page simple entities with no lazily loaded collections or attributes.
 	 * 	WARN: Failure to do so can easily exhaust memory at scale and will cause hibernate warnings.
 	 */
-	public Page<T> findAllBySearchAndPaginate(SearchQueryBuilder<T> searchQuery, Pageable pageReq) {
+	public Page<T> findAllBySearchAndPaginate(SearchQueryBuilder<T> searchQuery, Pageable pageReq)
+		throws InvalidPagingException {
 		applyUserId(searchQuery);
-		List<T> content = getPagedContent(searchQuery, pageReq);
+
 		Long totalCount = getTotalCount(searchQuery);
+
+		validatePageNumber(pageReq, totalCount);
+
+		if (totalCount == 0) {
+			// Short-circuit to avoid running possible long-running query
+			return new PageImpl<>(Collections.emptyList(), pageReq, totalCount);
+		}
+
+		List<T> content = getPagedContent(searchQuery, pageReq);
 
         return new PageImpl<>(content, pageReq, totalCount);
 	}
@@ -61,12 +72,16 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 	 *
 	 * The results will be paged and ordered based on the submitted searchQuery and pageReq.
     */
-	public Page<T> findAllBySearchPaginatingWithFetches(SearchQueryBuilder<T> searchQuery, Pageable pageReq) {
+	public Page<T> findAllBySearchPaginatingWithFetches(SearchQueryBuilder<T> searchQuery, Pageable pageReq)
+		throws InvalidPagingException {
 		applyUserId(searchQuery);
+
+		Long totalCount = getTotalCount(searchQuery);
+
+		validatePageNumber(pageReq, totalCount);
 
 		// First grab all the ids of the entities according to the criteria of the searchQuery, paging as specified in the pageReq.
 		List<String> content = getPagedContentIdsOnly(searchQuery, pageReq);
-		Long totalCount = getTotalCount(searchQuery);
 
 		Page<String> pagedIds = new PageImpl<>(content, pageReq, totalCount);
 
@@ -120,7 +135,7 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 		this.entityManager.refresh(entity);
 	}
 
-	public void fetchXrefs(Page<T> page, Class<T> searchClass) {
+	public void fetchXrefs(Page<T> page, Class<T> searchClass) throws InvalidPagingException {
 		SearchQueryBuilder<T> searchQuery = new SearchQueryBuilder<T>(searchClass);
 		searchQuery.leftJoinFetch("externalReferences", "externalReferences")
 				   .appendList(page.stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()), "id");
@@ -219,5 +234,14 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 			return content.get(0);
 		}
 		return 0L;
+	}
+
+	private void validatePageNumber(Pageable pageReq, Long totalCount) throws InvalidPagingException {
+		int reqPageNum = pageReq.getPageNumber();
+		if (reqPageNum != 0 && reqPageNum > Math.floor(((double) totalCount) / pageReq.getPageSize())) {
+			// Condition indicates a request was sent where the page requested exceeds the total number of pages.
+			// Instruct requester to send the correct request.
+			throw new InvalidPagingException();
+		}
 	}
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/PagingUtility.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/PagingUtility.java
@@ -3,6 +3,9 @@ package org.brapi.test.BrAPITestServer.service;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
+import org.brapi.test.BrAPITestServer.exceptions.InvalidPagingException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -10,12 +13,47 @@ import org.springframework.data.domain.Sort;
 
 import io.swagger.model.IndexPagination;
 import io.swagger.model.Metadata;
+import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
+
+@Component
 public class PagingUtility {
+	@Value("${paging.page-size.default:1000}")
+	private int defaultPageSize;
+	@Value("${paging.page-size.max-allowed:65000}")
+	private int maxAllowablePageSize;
+
+	private static int defaultPageSizeStatic;
+	private static int maxAllowablePageSizeStatic;
+
+	@PostConstruct
+	private void init() {
+		// Java made me do this - JL
+		defaultPageSizeStatic = defaultPageSize;
+		maxAllowablePageSizeStatic = maxAllowablePageSize;
+	}
+
 	public static void calculateMetaData(Metadata metaData) {
 		int totalCount = metaData.getPagination().getTotalCount();
 		int pageSize = metaData.getPagination().getPageSize();
 		metaData.getPagination().setTotalPages((totalCount / pageSize) + Integer.signum( totalCount % pageSize));
+	}
+
+	public static void validatePaging(Integer page, Integer pageSize) throws BrAPIServerException {
+		boolean pageValid = (page == null) || (page >= 0);
+		if (!pageValid)
+			throw new InvalidPagingException("page");
+		boolean pageSizeValid = (pageSize == null) || (pageSize >= 1);
+		if (!pageSizeValid)
+			throw new InvalidPagingException("pageSize");
+		if (pageSize != null && pageSize > maxAllowablePageSizeStatic) {
+			throw new InvalidPagingException("pageSize [Over maximum allowable page size of [" + maxAllowablePageSizeStatic + "]] ");
+		}
+	}
+
+	public static int getDefaultPageSize() {
+		return defaultPageSizeStatic;
 	}
 
 	public static Pageable getPageRequest(Metadata metaData) {
@@ -34,7 +72,7 @@ public class PagingUtility {
 			page = metaData.getPagination().getCurrentPage();
 		}
 
-		int pageSize = 1000;
+		int pageSize = defaultPageSizeStatic;
 		if (metaData.getPagination().getPageSize() != null && metaData.getPagination().getPageSize() > 0) {
 			pageSize = metaData.getPagination().getPageSize();
 		}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/SearchQueryBuilder.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/SearchQueryBuilder.java
@@ -32,10 +32,22 @@ public class SearchQueryBuilder<T> {
 	}
 
 	public String getQuery() {
+		if (sortClause.isBlank()) {
+			// By default, sort on entity id to have query result remain idempotent
+			sortClause = " ORDER BY entity.id ASC ";
+		}
+
 		return selectClause + whereClause + sortClause;
 	}
 
-	public String getIdQuery() { return selectOnlyIds + whereClause + sortClause;}
+	public String getIdQuery() {
+		if (sortClause.isBlank()) {
+			// By default, sort on entity id to have query result remain idempotent
+			sortClause = " ORDER BY entity.id ASC ";
+		}
+
+		return selectOnlyIds + whereClause + sortClause;
+	}
 
 	public Map<String, Object> getParams() {
 		return params;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/SearchQueryBuilder.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/SearchQueryBuilder.java
@@ -16,6 +16,7 @@ import io.swagger.model.core.SortOrder;
 public class SearchQueryBuilder<T> {
 
 	private String selectClause;
+	private String selectOnlyIds;
 	private String whereClause;
 	private String sortClause;
 	private Map<String, Object> params;
@@ -23,6 +24,7 @@ public class SearchQueryBuilder<T> {
 
 	public SearchQueryBuilder(Class<T> clazz) {
 		this.selectClause = "SELECT distinct entity FROM " + clazz.getSimpleName() + " entity ";
+		this.selectOnlyIds = "SELECT entity.id FROM " + clazz.getSimpleName() + " entity ";
 		this.whereClause = "WHERE 1=1 ";
 		this.sortClause = "";
 		this.params = new HashMap<>();
@@ -32,6 +34,8 @@ public class SearchQueryBuilder<T> {
 	public String getQuery() {
 		return selectClause + whereClause + sortClause;
 	}
+
+	public String getIdQuery() { return selectOnlyIds + whereClause + sortClause;}
 
 	public Map<String, Object> getParams() {
 		return params;
@@ -221,6 +225,7 @@ public class SearchQueryBuilder<T> {
 
 	public SearchQueryBuilder<T> join(String join, String name) {
 		this.selectClause += "JOIN " + entityPrefix(join) + " " + paramFilter(name) + " ";
+		this.selectOnlyIds += "JOIN " + entityPrefix(join) + " " + paramFilter(name) + " ";
 		return this;
 	}
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/SearchQueryBuilder.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/SearchQueryBuilder.java
@@ -1,11 +1,7 @@
 package org.brapi.test.BrAPITestServer.service;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -32,7 +28,7 @@ public class SearchQueryBuilder<T> {
 	}
 
 	public String getQuery() {
-		if (sortClause.isBlank()) {
+		if (sortClause.isEmpty()) {
 			// By default, sort on entity id to have query result remain idempotent
 			sortClause = " ORDER BY entity.id ASC ";
 		}
@@ -41,7 +37,7 @@ public class SearchQueryBuilder<T> {
 	}
 
 	public String getIdQuery() {
-		if (sortClause.isBlank()) {
+		if (sortClause.isEmpty()) {
 			// By default, sort on entity id to have query result remain idempotent
 			sortClause = " ORDER BY entity.id ASC ";
 		}
@@ -62,6 +58,15 @@ public class SearchQueryBuilder<T> {
 		if (list != null && !list.isEmpty()) {
 			this.whereClause += "AND " + entityPrefix(columnName) + " in :" + paramName + " ";
 			this.params.put(paramName, list);
+		}
+		return this;
+	}
+
+	public SearchQueryBuilder<T> appendIds(List<String> ids) {
+		String paramName = paramFilter("id");
+		if (ids != null && !ids.isEmpty()) {
+			this.whereClause += "AND " + entityPrefix("id") + " in :" + paramName + " ";
+			this.params.put(paramName, ids);
 		}
 		return this;
 	}
@@ -242,8 +247,37 @@ public class SearchQueryBuilder<T> {
 	}
 
 	public SearchQueryBuilder<T> leftJoinFetch(String join, String name) {
-		this.selectClause += "LEFT JOIN FETCH " + entityPrefix(join) + " " + paramFilter(name) + " ";
+		this.selectClause += generateLeftJoinFetch(join, name);
 		return this;
+	}
+
+	/**
+	 * Use this method to remove left join fetches from specific collection attributes so you can leverage the same query to
+	 * iterate through other lazily loaded collections on an entity you need to fetch.
+	 */
+	public SearchQueryBuilder<T> removeAndReplaceLeftJoinFetch(String join,
+															   String name,
+															   String existingJoin,
+															   String existingName) {
+
+		this.selectClause =
+				this.selectClause.replace(generateLeftJoinFetch(existingJoin, existingName), generateLeftJoinFetch(join, name));
+
+		return this;
+	}
+
+	/**
+	 * Use this method to remove left join fetches from specific collection attributes so you can leverage the same
+	 * base query criteria to add another join fetch with leftJoinFetch()
+	 */
+	public SearchQueryBuilder<T> removeLeftJoinFetch(String join, String name) {
+		this.selectClause =
+				this.selectClause.replace(generateLeftJoinFetch(join, name), "");
+		return this;
+	}
+
+	private String generateLeftJoinFetch(String join, String paramName) {
+		return "LEFT JOIN FETCH " + entityPrefix(join) + " " + paramFilter(paramName) + " ";
 	}
 
 	private String entityPrefix(String field) {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/SecurityUtils.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/SecurityUtils.java
@@ -1,0 +1,15 @@
+package org.brapi.test.BrAPITestServer.service;
+
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtils {
+    public static String getCurrentUserId() {
+        SecurityContext context = SecurityContextHolder.getContext();
+        String userId = "";
+        if (context.getAuthentication().getPrincipal() != null) {
+            userId = context.getAuthentication().getPrincipal().toString();
+        }
+        return userId;
+    }
+}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
@@ -87,7 +87,7 @@ public class ListService {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<ListEntity> searchQuery = buildQueryString(request);
 
-		Page<ListEntity> entityPage = listRepository.findAllBySearch(searchQuery, pageReq);
+		Page<ListEntity> entityPage = listRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 
 		List<ListSummary> data = entityPage.map(this::convertToSummary).getContent();
 		PagingUtility.calculateMetaData(metadata, entityPage);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
@@ -58,7 +58,7 @@ public class ListService {
 
 	public List<ListSummary> findLists(ListTypes listType, String listName, String listDbId, String listSource,
 			String programDbId, String commonCropName, String externalReferenceId, String externalReferenceID,
-			String externalReferenceSource, Metadata metadata) {
+			String externalReferenceSource, Metadata metadata) throws BrAPIServerException {
 		ListSearchRequest request = new ListSearchRequest();
 		if (listType != null) {
 			request.setListType(listType);
@@ -79,11 +79,11 @@ public class ListService {
 			request.addCommonCropNamesItem(commonCropName);
 		}
 		request.addExternalReferenceItem(externalReferenceId, externalReferenceID, externalReferenceSource);
-		
+
 		return findLists(request, metadata);
 	}
 
-	public List<ListSummary> findLists(ListSearchRequest request, Metadata metadata) {
+	public List<ListSummary> findLists(ListSearchRequest request, Metadata metadata) throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<ListEntity> searchQuery = buildQueryString(request);
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/LocationService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/LocationService.java
@@ -83,7 +83,7 @@ public class LocationService {
 				.appendList(request.getParentLocationDbIds(), "parentLocation.id")
 				.appendList(request.getParentLocationNames(), "parentLocation.name");
 
-		Page<LocationEntity> entityPage = locationRepository.findAllBySearch(searchQuery, pageReq);
+		Page<LocationEntity> entityPage = locationRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 
 		List<Location> data = entityPage.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, entityPage);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/LocationService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/LocationService.java
@@ -37,7 +37,8 @@ public class LocationService {
 
 	public List<Location> findLocations(String locationDbId, String locationType, String locationName,
 			String parentLocationDbId, String parentLocationName, String commonCropName, String programDbId,
-			String externalReferenceId, String externalReferenceID, String externalReferenceSource, Metadata metadata) {
+			String externalReferenceId, String externalReferenceID, String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 		LocationSearchRequest request = new LocationSearchRequest();
 		if (locationDbId != null)
 			request.addLocationDbIdsItem(locationDbId);
@@ -59,7 +60,8 @@ public class LocationService {
 		return findLocations(request, metadata);
 	}
 
-	public List<Location> findLocations(LocationSearchRequest request, Metadata metadata) {
+	public List<Location> findLocations(LocationSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<LocationEntity> searchQuery = new SearchQueryBuilder<LocationEntity>(LocationEntity.class);
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/PeopleService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/PeopleService.java
@@ -32,7 +32,8 @@ public class PeopleService {
 
 	public List<Person> findPeople(String firstName, String lastName, String personDbId, String userID,
 			String commonCropName, String programDbId, String externalReferenceId, String externalReferenceID,
-			String externalReferenceSource, Metadata metadata) {
+			String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 
 		PersonSearchRequest request = new PersonSearchRequest();
 		if (firstName != null)
@@ -52,7 +53,8 @@ public class PeopleService {
 		return findPeople(request, metadata);
 	}
 
-	public List<Person> findPeople(PersonSearchRequest request, Metadata metadata) {
+	public List<Person> findPeople(PersonSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<PersonEntity> searchQuery = new SearchQueryBuilder<PersonEntity>(PersonEntity.class)
 				.withExRefs(request.getExternalReferenceIDs(), request.getExternalReferenceSources())

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/PeopleService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/PeopleService.java
@@ -62,7 +62,7 @@ public class PeopleService {
 				.appendList(request.getMiddleNames(), "middleName").appendList(request.getPersonDbIds(), "id")
 				.appendList(request.getPhoneNumbers(), "phoneNumber").appendList(request.getUserIDs(), "userID");
 
-		Page<PersonEntity> entityPage = peopleRepository.findAllBySearch(searchQuery, pageReq);
+		Page<PersonEntity> entityPage = peopleRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 
 		List<Person> data = entityPage.map(this::convertToPerson).getContent();
 		PagingUtility.calculateMetaData(metadata, entityPage);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/ProgramService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/ProgramService.java
@@ -69,7 +69,7 @@ public class ProgramService {
 				.appendList(request.getObjectives(), "objective").appendList(request.getProgramDbIds(), "id")
 				.appendList(request.getProgramNames(), "name").appendEnumList(request.getProgramTypes(), "programType");
 
-		Page<ProgramEntity> page = programRepository.findAllBySearch(searchQuery, pageReq);
+		Page<ProgramEntity> page = programRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<Program> programs = page.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, page);
 		return programs;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/SeasonService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/SeasonService.java
@@ -44,7 +44,7 @@ public class SeasonService {
 		if (year != null)
 			searchQuery = searchQuery.appendSingle(year, "year");
 
-		Page<SeasonEntity> entityPage = seasonRepository.findAllBySearch(searchQuery, pageReq);
+		Page<SeasonEntity> entityPage = seasonRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 
 		List<Season> data = entityPage.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, entityPage);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/SeasonService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/SeasonService.java
@@ -32,7 +32,8 @@ public class SeasonService {
 	}
 
 	public List<Season> findSeasons(String seasonDbId, String season, String seasonName, Integer year,
-			Metadata metadata) {
+			Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<SeasonEntity> searchQuery = new SearchQueryBuilder<SeasonEntity>(SeasonEntity.class);
 		if (seasonDbId != null)

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/StudyService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/StudyService.java
@@ -78,7 +78,7 @@ public class StudyService {
 			String seasonDbId, String trialDbId, String studyDbId, String studyName, String studyCode, String studyPUI,
 			String germplasmDbId, String observationVariableDbId, String externalReferenceId,
 			String externalReferenceID, String externalReferenceSource, Boolean active, String sortBy, String sortOrder,
-			Metadata metadata) {
+			Metadata metadata)  throws BrAPIServerException {
 
 		StudySearchRequest request = new StudySearchRequest();
 		if (commonCropName != null)
@@ -117,7 +117,8 @@ public class StudyService {
 		return findStudies(request, metadata);
 	}
 
-	public List<Study> findStudies(StudySearchRequest request, Metadata metaData) {
+	public List<Study> findStudies(StudySearchRequest request, Metadata metaData)
+		throws BrAPIServerException {
 
 		Pageable pageReq = PagingUtility.getPageRequest(metaData);
 		SearchQueryBuilder<StudyEntity> searchQuery = new SearchQueryBuilder<StudyEntity>(StudyEntity.class);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/StudyService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/StudyService.java
@@ -149,7 +149,7 @@ public class StudyService {
 				.appendList(request.getTrialDbIds(), "trial.id").appendList(request.getTrialNames(), "trial.trialName")
 				.withSort(getSortByField(request.getSortBy()), request.getSortOrder());
 
-		Page<StudyEntity> studiesPage = studyRepository.findAllBySearch(searchQuery, pageReq);
+		Page<StudyEntity> studiesPage = studyRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		PagingUtility.calculateMetaData(metaData, studiesPage);
 
 		List<Study> studies = studiesPage.map(this::convertFromEntity).getContent();

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/TrialService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/TrialService.java
@@ -71,7 +71,8 @@ public class TrialService {
 			@Valid String locationDbId, @Valid LocalDate searchDateRangeStart, @Valid LocalDate searchDateRangeEnd,
 			@Valid String studyDbId, @Valid String trialDbId, @Valid String trialName, @Valid String trialPUI,
 			@Valid String externalReferenceId, @Valid String externalReferenceID, @Valid String externalReferenceSource,
-			@Valid Boolean active, @Valid String sortBy, @Valid String sortOrder, Metadata metadata) {
+			@Valid Boolean active, @Valid String sortBy, @Valid String sortOrder, Metadata metadata)
+		throws BrAPIServerException {
 
 		TrialSearchRequest request = new TrialSearchRequest();
 		if (active != null)
@@ -105,7 +106,8 @@ public class TrialService {
 		return findTrials(request, metadata);
 	}
 
-	public List<Trial> findTrials(@Valid TrialSearchRequest request, Metadata metadata) {
+	public List<Trial> findTrials(@Valid TrialSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<TrialEntity> searchQuery = new SearchQueryBuilder<TrialEntity>(TrialEntity.class);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/TrialService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/TrialService.java
@@ -129,7 +129,7 @@ public class TrialService {
 				.appendDateRange(request.getSearchDateRangeStart(), request.getSearchDateRangeEnd(), "startDate")
 				.withSort(getSortByField(request.getSortBy()), request.getSortOrder());
 
-		Page<TrialEntity> trialsPage = trialRepository.findAllBySearch(searchQuery, pageReq);
+		Page<TrialEntity> trialsPage = trialRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		PagingUtility.calculateMetaData(metadata, trialsPage);
 
 		List<Trial> trials = trialsPage.map(this::convertFromEntity).getContent();

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/AlleleMatrixService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/AlleleMatrixService.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.math.NumberUtils;
+import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
 import org.brapi.test.BrAPITestServer.model.entity.geno.CallEntity;
 import org.brapi.test.BrAPITestServer.model.entity.geno.CallSetEntity;
 import org.brapi.test.BrAPITestServer.model.entity.geno.VariantEntity;
@@ -43,7 +44,8 @@ public class AlleleMatrixService {
 			Integer dimensionCallSetPage, Integer dimensionCallSetPageSize, Boolean preview,
 			String dataMatrixNames, String dataMatrixAbbreviations, String positionRange, String germplasmDbId,
 			String germplasmName, String germplasmPUI, String callSetDbId, String variantDbId, String variantSetDbId,
-			Boolean expandHomozygotes, String unknownString, String sepPhased, String sepUnphased, Metadata metadata) {
+			Boolean expandHomozygotes, String unknownString, String sepPhased, String sepUnphased, Metadata metadata)
+		throws BrAPIServerException {
 
 		AlleleMatrixSearchRequestPagination variantPage = new AlleleMatrixSearchRequestPagination()
 				.dimension(DimensionEnum.VARIANTS);
@@ -111,7 +113,8 @@ public class AlleleMatrixService {
 		return findAlleleMatrix(request, metadata);
 	}
 
-	public AlleleMatrix findAlleleMatrix(AlleleMatrixSearchRequest request, Metadata metadata) {
+	public AlleleMatrix findAlleleMatrix(AlleleMatrixSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		AlleleMatrix matrixResponse = new AlleleMatrix();
 		AlleleMatrixPagination variantPage = new AlleleMatrixPagination().dimension(DimensionEnum.VARIANTS);
 		AlleleMatrixPagination callSetPage = new AlleleMatrixPagination().dimension(DimensionEnum.CALLSETS);
@@ -221,7 +224,8 @@ public class AlleleMatrixService {
 		}
 	}
 
-	private List<CallEntity> findCalls(AlleleMatrix matrixResponse, AlleleMatrixSearchRequest request) {
+	private List<CallEntity> findCalls(AlleleMatrix matrixResponse, AlleleMatrixSearchRequest request)
+		throws BrAPIServerException {
 		CallsSearchRequest callSearchReq = new CallsSearchRequest();
 		callSearchReq.setCallSetDbIds(matrixResponse.getCallSetDbIds());
 		callSearchReq.setVariantDbIds(matrixResponse.getVariantDbIds());
@@ -241,7 +245,8 @@ public class AlleleMatrixService {
 		return callService.findCallEntities(callSearchReq, metadata);
 	}
 
-	private List<VariantEntity> findVariants(AlleleMatrixSearchRequest request, AlleleMatrixPagination page) {
+	private List<VariantEntity> findVariants(AlleleMatrixSearchRequest request, AlleleMatrixPagination page)
+		throws BrAPIServerException {
 		VariantsSearchRequest variantSearchReq = new VariantsSearchRequest();
 		variantSearchReq.setCallSetDbIds(request.getCallSetDbIds());
 		variantSearchReq.setVariantDbIds(request.getVariantDbIds());
@@ -269,7 +274,8 @@ public class AlleleMatrixService {
 		return variants;
 	}
 
-	private List<CallSetEntity> findCallSets(AlleleMatrixSearchRequest request, AlleleMatrixPagination page) {
+	private List<CallSetEntity> findCallSets(AlleleMatrixSearchRequest request, AlleleMatrixPagination page)
+		throws BrAPIServerException {
 		CallSetsSearchRequest callSetSearchReq = new CallSetsSearchRequest();
 		callSetSearchReq.setCallSetDbIds(request.getCallSetDbIds());
 		callSetSearchReq.setGermplasmDbIds(request.getGermplasmDbIds());

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/CallService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/CallService.java
@@ -41,7 +41,8 @@ public class CallService {
 	}
 
 	public CallsListResponseResult findCalls(String callSetDbId, String variantDbId, String variantSetDbId,
-			Boolean expandHomozygotes, String unknownString, String sepPhased, String sepUnphased, Metadata metadata) {
+			Boolean expandHomozygotes, String unknownString, String sepPhased, String sepUnphased, Metadata metadata)
+		throws BrAPIServerException {
 		CallsSearchRequest request = new CallsSearchRequest();
 		if (callSetDbId != null)
 			request.addCallSetDbIdsItem(callSetDbId);
@@ -57,7 +58,8 @@ public class CallService {
 		return findCalls(request, metadata);
 	}
 
-	public CallsListResponseResult findCalls(CallsSearchRequest request, Metadata metadata) {
+	public CallsListResponseResult findCalls(CallsSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		List<Call> calls = findCallEntities(request, metadata).stream().map(e -> {
 			return convertFromEntityWithFormatting(e, request);
 		}).collect(Collectors.toList());
@@ -65,7 +67,8 @@ public class CallService {
 		return result;
 	}
 
-	public List<CallEntity> findCallEntities(CallsSearchRequest request, Metadata metadata) {
+	public List<CallEntity> findCallEntities(CallsSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<CallEntity> searchQuery = new SearchQueryBuilder<CallEntity>(CallEntity.class)
 				.appendList(request.getCallSetDbIds(), "callSet.id").appendList(request.getVariantDbIds(), "variant.id")

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/CallService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/CallService.java
@@ -71,7 +71,7 @@ public class CallService {
 				.appendList(request.getCallSetDbIds(), "callSet.id").appendList(request.getVariantDbIds(), "variant.id")
 				.appendList(request.getVariantSetDbIds(), "variant.variantSet.id");
 
-		Page<CallEntity> page = callRepository.findAllBySearch(searchQuery, pageReq);
+		Page<CallEntity> page = callRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		PagingUtility.calculateMetaData(metadata, page);
 		return page.getContent();
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/CallSetService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/CallSetService.java
@@ -66,7 +66,7 @@ public class CallSetService {
 				.appendList(request.getSampleDbIds(), "sample.id")
 				.appendList(request.getSampleNames(), "sample.sampleName");
 
-		Page<CallSetEntity> page = callSetRepository.findAllBySearch(searchQuery, pageReq);
+		Page<CallSetEntity> page = callSetRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		PagingUtility.calculateMetaData(metadata, page);
 		return page.getContent();
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/CallSetService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/CallSetService.java
@@ -30,7 +30,8 @@ public class CallSetService {
 	}
 
 	public List<CallSet> findCallSets(String callSetDbId, String callSetName, String variantSetDbId, String sampleDbId,
-			String germplasmDbId, String externalReferenceId, String externalReferenceSource, Metadata metadata) {
+			String germplasmDbId, String externalReferenceId, String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 		CallSetsSearchRequest request = new CallSetsSearchRequest();
 		if (callSetDbId != null)
 			request.addCallSetDbIdsItem(callSetDbId);
@@ -47,11 +48,13 @@ public class CallSetService {
 		return findCallSets(request, metadata);
 	}
 
-	public List<CallSet> findCallSets(CallSetsSearchRequest request, Metadata metadata) {
+	public List<CallSet> findCallSets(CallSetsSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		return findCallSetEntities(request, metadata).stream().map(this::convertFromEntity).collect(Collectors.toList());
 	}
 
-	public List<CallSetEntity> findCallSetEntities(CallSetsSearchRequest request, Metadata metadata) {
+	public List<CallSetEntity> findCallSetEntities(CallSetsSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<CallSetEntity> searchQuery = new SearchQueryBuilder<CallSetEntity>(CallSetEntity.class);
 		if(request.getVariantSetDbIds() != null) {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/GenomeMapService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/GenomeMapService.java
@@ -35,7 +35,8 @@ public class GenomeMapService {
 	}
 
 	public List<GenomeMap> findMaps(String commonCropName, String mapPUI, String scientificName, String type,
-			String programDbId, String trialDbId, String studyDbId, Metadata metadata) {
+			String programDbId, String trialDbId, String studyDbId, Metadata metadata)
+		throws BrAPIServerException {
 		SearchQueryBuilder<GenomeMapEntity> searchQuery = new SearchQueryBuilder<GenomeMapEntity>(GenomeMapEntity.class);
 
 		if (programDbId != null || trialDbId != null || studyDbId != null) {
@@ -68,7 +69,8 @@ public class GenomeMapService {
 		return map;
 	}
 
-	public List<LinkageGroup> findLinkageGroups(String mapDbId, Metadata metadata) {
+	public List<LinkageGroup> findLinkageGroups(String mapDbId, Metadata metadata)
+		throws BrAPIServerException {
 		SearchQueryBuilder<LinkageGroupEntity> searchQuery = new SearchQueryBuilder<LinkageGroupEntity>(
 				LinkageGroupEntity.class).appendSingle(mapDbId, "genomeMap.id");
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/GenomeMapService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/GenomeMapService.java
@@ -51,7 +51,7 @@ public class GenomeMapService {
 				.appendSingle(studyDbId, "*study.id");
 
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
-		Page<GenomeMapEntity> page = genomeMapRepository.findAllBySearch(searchQuery, pageReq);
+		Page<GenomeMapEntity> page = genomeMapRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<GenomeMap> maps = page.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, page);
 		return maps;
@@ -73,7 +73,7 @@ public class GenomeMapService {
 				LinkageGroupEntity.class).appendSingle(mapDbId, "genomeMap.id");
 
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
-		Page<LinkageGroupEntity> page = linkageGroupRepository.findAllBySearch(searchQuery, pageReq);
+		Page<LinkageGroupEntity> page = linkageGroupRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<LinkageGroup> linkageGroups = page.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, page);
 		return linkageGroups;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/MarkerPositionService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/MarkerPositionService.java
@@ -2,6 +2,7 @@ package org.brapi.test.BrAPITestServer.service.geno;
 
 import java.util.List;
 
+import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
 import org.brapi.test.BrAPITestServer.model.entity.geno.MarkerPositionEntity;
 import org.brapi.test.BrAPITestServer.repository.geno.MarkerPositionRepository;
 import org.brapi.test.BrAPITestServer.service.PagingUtility;
@@ -24,7 +25,8 @@ public class MarkerPositionService {
 	}
 
 	public List<MarkerPosition> findMarkerPositions(String mapDbId, String linkageGroupName, String variantDbId,
-			Integer maxPosition, Integer minPosition, Metadata metadata) {
+			Integer maxPosition, Integer minPosition, Metadata metadata)
+		throws BrAPIServerException {
 		MarkerPositionSearchRequest request = new MarkerPositionSearchRequest();
 		if (mapDbId != null)
 			request.addMapDbIdsItem(mapDbId);
@@ -38,7 +40,8 @@ public class MarkerPositionService {
 		return findMarkerPositions(request, metadata);
 	}
 
-	public List<MarkerPosition> findMarkerPositions(MarkerPositionSearchRequest request, Metadata metadata) {
+	public List<MarkerPosition> findMarkerPositions(MarkerPositionSearchRequest request, Metadata metadata)
+		throws BrAPIServerException  {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<MarkerPositionEntity> searchQuery = new SearchQueryBuilder<MarkerPositionEntity>(
 				MarkerPositionEntity.class).appendList(request.getLinkageGroupNames(), "linkageGroup.linkageGroupName")

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/MarkerPositionService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/MarkerPositionService.java
@@ -46,7 +46,7 @@ public class MarkerPositionService {
 						.appendList(request.getMapDbIds(), "linkageGroup.genomeMap.id")
 						.appendNumberRange(request.getMinPosition(), request.getMaxPosition(), "position");
 
-		Page<MarkerPositionEntity> page = markerPositionRepository.findAllBySearch(searchQuery, pageReq);
+		Page<MarkerPositionEntity> page = markerPositionRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<MarkerPosition> markerPositions = page.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, page);
 		return markerPositions;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/PlateService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/PlateService.java
@@ -48,7 +48,8 @@ public class PlateService {
 	public List<Plate> findPlates(String sampleDbId, String sampleName, String sampleGroupDbId,
 			String observationUnitDbId, String plateDbId, String plateName, String germplasmDbId, String studyDbId,
 			String trialDbId, String commonCropName, String programDbId, String externalReferenceId,
-			String externalReferenceID, String externalReferenceSource, Metadata metadata) {
+			String externalReferenceID, String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 		PlateSearchRequest request = new PlateSearchRequest();
 		if (sampleDbId != null)
 			request.addSampleDbIdsItem(sampleDbId);
@@ -78,7 +79,8 @@ public class PlateService {
 		return findPlates(request, metadata);
 	}
 
-	public List<Plate> findPlates(PlateSearchRequest request, Metadata metadata) {
+	public List<Plate> findPlates(PlateSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<PlateEntity> searchQuery = new SearchQueryBuilder<PlateEntity>(PlateEntity.class);
 		if (request.getSampleDbIds() != null || request.getSampleNames() != null

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/PlateService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/PlateService.java
@@ -101,7 +101,7 @@ public class PlateService {
 				.appendList(request.getTrialNames(), "trial.trialName").appendList(request.getStudyDbIds(), "study.id")
 				.appendList(request.getStudyNames(), "study.studyName");
 
-		Page<PlateEntity> page = plateRepository.findAllBySearch(searchQuery, pageReq);
+		Page<PlateEntity> page = plateRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<Plate> plates = page.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, page);
 		return plates;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/ReferenceService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/ReferenceService.java
@@ -83,7 +83,7 @@ public class ReferenceService {
 				.appendNumberRange(request.getMinLength(), request.getMaxLength(), "length")
 				.appendSingle(request.isIsDerived(), "referenceSet.isDerived");
 
-		Page<ReferenceEntity> page = referenceRepository.findAllBySearch(searchQuery, pageReq);
+		Page<ReferenceEntity> page = referenceRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<Reference> references = page.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, page);
 		return references;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/ReferenceService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/ReferenceService.java
@@ -47,7 +47,8 @@ public class ReferenceService {
 	public List<Reference> findReferences(String referenceDbId, String referenceSetDbId, String accession,
 			String md5checksum, Boolean isDerived, Integer minLength, Integer maxLength, String trialDbId,
 			String studyDbId, String commonCropName, String programDbId, String externalReferenceId,
-			String externalReferenceSource, Metadata metadata) {
+			String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 		ReferencesSearchRequest request = new ReferencesSearchRequest();
 		if (referenceDbId != null)
 			request.addReferenceDbIdsItem(referenceDbId);
@@ -74,7 +75,8 @@ public class ReferenceService {
 		return findReferences(request, metadata);
 	}
 
-	public List<Reference> findReferences(@Valid ReferencesSearchRequest request, Metadata metadata) {
+	public List<Reference> findReferences(@Valid ReferencesSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<ReferenceEntity> searchQuery = new SearchQueryBuilder<ReferenceEntity>(ReferenceEntity.class)
 				.appendList(request.getAccessions(), "referenceSet.sourceGermplasm.accessionNumber")

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/ReferenceSetService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/ReferenceSetService.java
@@ -33,7 +33,8 @@ public class ReferenceSetService {
 
 	public List<ReferenceSet> findReferenceSets(String referenceSetDbId, String accession, String assemblyPUI,
 			String md5checksum, String trialDbId, String studyDbId, String commonCropName, String programDbId,
-			String externalReferenceId, String externalReferenceSource, Metadata metadata) {
+			String externalReferenceId, String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 		ReferenceSetsSearchRequest request = new ReferenceSetsSearchRequest();
 		if (referenceSetDbId != null)
 			request.addReferenceSetDbIdsItem(referenceSetDbId);
@@ -57,7 +58,8 @@ public class ReferenceSetService {
 		return findReferenceSets(request, metadata);
 	}
 
-	public List<ReferenceSet> findReferenceSets(ReferenceSetsSearchRequest request, Metadata metadata) {
+	public List<ReferenceSet> findReferenceSets(ReferenceSetsSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<ReferenceSetEntity> searchQuery = new SearchQueryBuilder<ReferenceSetEntity>(
 				ReferenceSetEntity.class).appendList(request.getAccessions(), "sourceGermplasm.accessionNumber")

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/ReferenceSetService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/ReferenceSetService.java
@@ -65,7 +65,7 @@ public class ReferenceSetService {
 						.appendList(request.getMd5checksums(), "md5checksum")
 						.appendList(request.getReferenceSetDbIds(), "id");
 
-		Page<ReferenceSetEntity> page = referenceSetRepository.findAllBySearch(searchQuery, pageReq);
+		Page<ReferenceSetEntity> page = referenceSetRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<ReferenceSet> referenceSets = page.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, page);
 		return referenceSets;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/SampleService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/SampleService.java
@@ -87,7 +87,8 @@ public class SampleService {
 	public List<Sample> findSamples(String sampleDbId, String sampleName, String sampleGroupDbId,
 			String observationUnitDbId, String plateDbId, String plateName, String germplasmDbId, String studyDbId,
 			String trialDbId, String commonCropName, String programDbId, String externalReferenceId,
-			String externalReferenceID, String externalReferenceSource, Metadata metadata) {
+			String externalReferenceID, String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 		SampleSearchRequest request = new SampleSearchRequest();
 		if (sampleDbId != null)
 			request.addSampleDbIdsItem(sampleDbId);
@@ -117,7 +118,8 @@ public class SampleService {
 		return findSamples(request, metadata);
 	}
 
-	public List<Sample> findSamples(SampleSearchRequest request, Metadata metadata) {
+	public List<Sample> findSamples(SampleSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<SampleEntity> searchQuery = new SearchQueryBuilder<SampleEntity>(SampleEntity.class)
 				.withExRefs(request.getExternalReferenceIDs(), request.getExternalReferenceSources())

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/SampleService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/SampleService.java
@@ -135,7 +135,7 @@ public class SampleService {
 				.appendList(request.getStudyDbIds(), "plate.study.id")
 				.appendList(request.getStudyNames(), "plate.study.studyName");
 
-		Page<SampleEntity> page = sampleRepository.findAllBySearch(searchQuery, pageReq);
+		Page<SampleEntity> page = sampleRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<Sample> samples = page.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, page);
 		return samples;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/VariantService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/VariantService.java
@@ -31,7 +31,8 @@ public class VariantService {
 	}
 
 	public List<Variant> findVariants(String variantDbId, String variantSetDbId, String referenceDbId,
-			String referenceSetDbId, String externalReferenceId, String externalReferenceSource, Metadata metadata) {
+			String referenceSetDbId, String externalReferenceId, String externalReferenceSource, Metadata metadata)
+	throws BrAPIServerException{
 
 		VariantsSearchRequest request = new VariantsSearchRequest();
 		if (variantSetDbId != null)
@@ -48,12 +49,14 @@ public class VariantService {
 		return findVariants(request, metadata);
 	}
 
-	public List<Variant> findVariants(VariantsSearchRequest request, Metadata metadata) {
+	public List<Variant> findVariants(VariantsSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		return findVariantEntities(request, metadata).stream().map(this::convertFromEntity)
 				.collect(Collectors.toList());
 	}
 
-	public List<VariantEntity> findVariantEntities(VariantsSearchRequest request, Metadata metadata) {
+	public List<VariantEntity> findVariantEntities(VariantsSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<VariantEntity> searchQuery = new SearchQueryBuilder<VariantEntity>(VariantEntity.class);
 		if (request.getCallSetDbIds() != null && !request.getCallSetDbIds().isEmpty()) {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/VariantService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/VariantService.java
@@ -63,7 +63,7 @@ public class VariantService {
 		searchQuery = searchQuery.appendList(request.getVariantSetDbIds(), "variantSet.id")
 				.appendList(request.getVariantDbIds(), "id");
 
-		Page<VariantEntity> page = variantRepository.findAllBySearch(searchQuery, pageReq);
+		Page<VariantEntity> page = variantRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		PagingUtility.calculateMetaData(metadata, page);
 		return page.getContent();
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/VariantSetService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/VariantSetService.java
@@ -55,7 +55,8 @@ public class VariantSetService {
 
 	public List<VariantSet> findVariantSets(String variantSetDbId, String variantDbId, String callSetDbId,
 			String studyDbId, String studyName, String referenceSetDbId, String commonCropName, String programDbId,
-			String externalReferenceId, String externalReferenceSource, Metadata metadata) {
+			String externalReferenceId, String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 		VariantSetsSearchRequest request = new VariantSetsSearchRequest();
 		if (variantSetDbId != null)
 			request.addVariantSetDbIdsItem(variantSetDbId);
@@ -78,13 +79,15 @@ public class VariantSetService {
 		return findVariantSets(request, metadata);
 	}
 
-	public List<VariantSet> findVariantSets(VariantSetsSearchRequest request, Metadata metadata) {
+	public List<VariantSet> findVariantSets(VariantSetsSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		List<VariantSet> variantSets = findVariantSetEntities(request, metadata).stream().map(this::convertFromEntity)
 				.collect(Collectors.toList());
 		return variantSets;
 	}
 
-	private List<VariantSetEntity> findVariantSetEntities(VariantSetsSearchRequest request, Metadata metadata) {
+	private List<VariantSetEntity> findVariantSetEntities(VariantSetsSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<VariantSetEntity> searchQuery = new SearchQueryBuilder<VariantSetEntity>(
 				VariantSetEntity.class);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/VariantSetService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/VariantSetService.java
@@ -97,7 +97,7 @@ public class VariantSetService {
 		searchQuery.appendList(request.getStudyDbIds(), "study.id")
 				.appendList(request.getStudyNames(), "study.studyName").appendList(request.getVariantSetDbIds(), "id");
 
-		Page<VariantSetEntity> page = variantSetRepository.findAllBySearch(searchQuery, pageReq);
+		Page<VariantSetEntity> page = variantSetRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		PagingUtility.calculateMetaData(metadata, page);
 		return page.getContent();
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/CrossService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/CrossService.java
@@ -81,7 +81,7 @@ public class CrossService {
 		if (plannedCross != null)
 			searchQuery = searchQuery.appendSingle(plannedCross, "planned");
 
-		Page<CrossEntity> page = crossRepository.findAllBySearch(searchQuery, pageReq);
+		Page<CrossEntity> page = crossRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		PagingUtility.calculateMetaData(metadata, page);
 		return page;
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/CrossService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/CrossService.java
@@ -47,27 +47,30 @@ public class CrossService {
 		this.crossParentService = crossParentService;
 	}
 
-	public List<Cross> findCrosses(String crossingProjectDbId, String crossingProjectName, String crossDbId,
-			String crossName, String commonCropName, String programDbId, String externalReferenceId,
-			String externalReferenceID, String externalReferenceSource, Metadata metadata) {
-		List<Cross> crosses = findCrossEntities(crossingProjectDbId, crossingProjectName, crossDbId, crossName, null,
-				commonCropName, programDbId, externalReferenceId, externalReferenceID, externalReferenceSource, false,
+	public List<Cross> findCrosses(String crossingProjectDbId, String crossDbId,
+								   String externalReferenceID, String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
+		List<Cross> crosses = findCrossEntities(crossingProjectDbId, crossDbId,
+				externalReferenceID, externalReferenceSource, false,
 				metadata).map(this::convertToCross).getContent();
 		return crosses;
 	}
 
-	public List<PlannedCross> findPlannedCrosses(String crossingProjectDbId, String crossingProjectName,
-			String crossDbId, String crossName, String status, String commonCropName, String programDbId,
-			String externalReferenceId, String externalReferenceID, String externalReferenceSource, Metadata metadata) {
-		List<PlannedCross> crosses = findCrossEntities(crossingProjectDbId, crossingProjectName, crossDbId, crossName, status,
-				commonCropName, programDbId, externalReferenceId, externalReferenceID, externalReferenceSource, true,
+	public List<PlannedCross> findPlannedCrosses(String crossingProjectDbId,
+												 String crossDbId,
+												 String externalReferenceID, String externalReferenceSource,
+												 Metadata metadata)
+		throws BrAPIServerException {
+		List<PlannedCross> crosses = findCrossEntities(crossingProjectDbId, crossDbId,
+				externalReferenceID, externalReferenceSource, true,
 				metadata).map(this::convertToPlanned).getContent();
 		return crosses;
 	}
 
-	public Page<CrossEntity> findCrossEntities(String crossingProjectDbId, String crossingProjectName, String crossDbId,
-			String crossName, String status, String commonCropName, String programDbId, String externalReferenceId,
-			String externalReferenceID, String externalReferenceSource, Boolean plannedCross, Metadata metadata) {
+	public Page<CrossEntity> findCrossEntities(String crossingProjectDbId, String crossDbId,
+											   String externalReferenceID, String externalReferenceSource,
+											   Boolean plannedCross, Metadata metadata)
+		throws BrAPIServerException {
 
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<CrossEntity> searchQuery = new SearchQueryBuilder<CrossEntity>(CrossEntity.class);
@@ -224,7 +227,7 @@ public class CrossService {
 		if (cross.getCrossName() != null)
 			entity.setName(cross.getCrossName());
 		if (cross.getPlannedCrossDbId() != null) {
-			List<CrossEntity> plannedEntity = findCrossEntities(null, null, cross.getPlannedCrossDbId(), null, null, null, null, null, null, null, true, null).getContent();
+			List<CrossEntity> plannedEntity = findCrossEntities(null, cross.getPlannedCrossDbId(), null, null, true, null).getContent();
 			entity.setPlannedCross(plannedEntity.get(0));
 		}
 		if (cross.getPollinationEvents() != null) {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/CrossingProjectService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/CrossingProjectService.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import io.swagger.model.IndexPagination;
 import jakarta.validation.Valid;
 
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerDbIdNotFoundException;
@@ -41,8 +40,9 @@ public class CrossingProjectService {
 	}
 
 	public List<CrossingProject> findCrossingProjects(String crossingProjectDbId, String crossingProjectName,
-			Boolean includePotentialParents, String commonCropName, String programDbId, String externalReferenceId,
-			String externalReferenceID, String externalReferenceSource, Metadata metadata) {
+			Boolean includePotentialParents, String commonCropName, String programDbId,
+													  String externalReferenceID, String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 
 		SearchQueryBuilder<CrossingProjectEntity> searchQuery = new SearchQueryBuilder<CrossingProjectEntity>(
@@ -67,26 +67,6 @@ public class CrossingProjectService {
 		}
 		PagingUtility.calculateMetaData(metadata, page);
 		return crossingProjects;
-	}
-
-	public List<CrossingProjectEntity> findCrossingProjectsByIds(List<String> crossingProjectIds) {
-		Metadata metadata = new Metadata().pagination(new IndexPagination());
-		Pageable pageReq = PagingUtility.getPageRequest(metadata);
-
-		SearchQueryBuilder<CrossingProjectEntity> searchQuery = new SearchQueryBuilder<CrossingProjectEntity>(
-				CrossingProjectEntity.class);
-
-		if (crossingProjectIds != null && !crossingProjectIds.isEmpty()) {
-			searchQuery = searchQuery.appendList(crossingProjectIds, "id");
-		}
-
-		Page<CrossingProjectEntity> page = crossingProjectRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
-
-		if (page.hasContent()) {
-			return page.getContent();
-		}
-
-		return null;
 	}
 
 	public CrossingProject getCrossingProject(String crossingProjectDbId) throws BrAPIServerException {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/CrossingProjectService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/CrossingProjectService.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import io.swagger.model.IndexPagination;
 import jakarta.validation.Valid;
 
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerDbIdNotFoundException;
@@ -59,13 +60,33 @@ public class CrossingProjectService {
 			searchQuery = searchQuery.withExRefs(Arrays.asList(externalReferenceID),
 					Arrays.asList(externalReferenceSource));
 
-		Page<CrossingProjectEntity> page = crossingProjectRepository.findAllBySearch(searchQuery, pageReq);
+		Page<CrossingProjectEntity> page = crossingProjectRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<CrossingProject> crossingProjects = new ArrayList<>();
 		for (CrossingProjectEntity entity : page) {
 			crossingProjects.add(convertFromEntity(entity, includePotentialParents));
 		}
 		PagingUtility.calculateMetaData(metadata, page);
 		return crossingProjects;
+	}
+
+	public List<CrossingProjectEntity> findCrossingProjectsByIds(List<String> crossingProjectIds) {
+		Metadata metadata = new Metadata().pagination(new IndexPagination());
+		Pageable pageReq = PagingUtility.getPageRequest(metadata);
+
+		SearchQueryBuilder<CrossingProjectEntity> searchQuery = new SearchQueryBuilder<CrossingProjectEntity>(
+				CrossingProjectEntity.class);
+
+		if (crossingProjectIds != null && !crossingProjectIds.isEmpty()) {
+			searchQuery = searchQuery.appendList(crossingProjectIds, "id");
+		}
+
+		Page<CrossingProjectEntity> page = crossingProjectRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
+
+		if (page.hasContent()) {
+			return page.getContent();
+		}
+
+		return null;
 	}
 
 	public CrossingProject getCrossingProject(String crossingProjectDbId) throws BrAPIServerException {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmAttributeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmAttributeService.java
@@ -125,7 +125,7 @@ public class GermplasmAttributeService {
 				.appendList(request.getOntologyDbIds(), "ontology.id")
 				.appendList(request.getCommonCropNames(), "crop.crop_name");
 
-		Page<GermplasmAttributeDefinitionEntity> page = attributeRepository.findAllBySearch(searchQuery, pageReq);
+		Page<GermplasmAttributeDefinitionEntity> page = attributeRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<GermplasmAttribute> attributes = page.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, page);
 		return attributes;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmAttributeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmAttributeService.java
@@ -43,7 +43,8 @@ public class GermplasmAttributeService {
 			String attributeName, String attributePUI, String germplasmDbId, String methodDbId, String methodName,
 			String methodPUI, String scaleDbId, String scaleName, String scalePUI, String traitDbId, String traitName,
 			String traitPUI, String commonCropName, String programDbId, String externalReferenceId,
-			String externalReferenceID, String externalReferenceSource, Metadata metadata) {
+			String externalReferenceID, String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 
 		GermplasmAttributeSearchRequest request = new GermplasmAttributeSearchRequest();
 		if (attributeCategory != null)
@@ -85,7 +86,7 @@ public class GermplasmAttributeService {
 	}
 
 	public List<GermplasmAttribute> findGermplasmAttributes(@Valid GermplasmAttributeSearchRequest request,
-			Metadata metadata) {
+			Metadata metadata) throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<GermplasmAttributeDefinitionEntity> searchQuery = new SearchQueryBuilder<GermplasmAttributeDefinitionEntity>(
 				GermplasmAttributeDefinitionEntity.class);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmAttributeValueService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmAttributeValueService.java
@@ -78,7 +78,7 @@ public class GermplasmAttributeValueService {
 						.appendList(request.getGermplasmDbIds(), "germplasm.id")
 						.appendList(request.getGermplasmNames(), "germplasm.germplasmName");
 
-		Page<GermplasmAttributeValueEntity> page = attributeValueRepository.findAllBySearch(searchQuery, pageReq);
+		Page<GermplasmAttributeValueEntity> page = attributeValueRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<GermplasmAttributeValue> attributeValues = page.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, page);
 		return attributeValues;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmAttributeValueService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmAttributeValueService.java
@@ -40,7 +40,8 @@ public class GermplasmAttributeValueService {
 
 	public List<GermplasmAttributeValue> findGermplasmAttributeValues(String attributeValueDbId, String attributeDbId,
 			String attributeName, String germplasmDbId, String commonCropName, String programDbId,
-			String externalReferenceId, String externalReferenceID, String externalReferenceSource, Metadata metadata) {
+			String externalReferenceId, String externalReferenceID, String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 
 		GermplasmAttributeValueSearchRequest request = new GermplasmAttributeValueSearchRequest();
 		if (attributeValueDbId != null)
@@ -62,7 +63,8 @@ public class GermplasmAttributeValueService {
 	}
 
 	public List<GermplasmAttributeValue> findGermplasmAttributeValues(
-			@Valid GermplasmAttributeValueSearchRequest request, Metadata metadata) {
+			@Valid GermplasmAttributeValueSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<GermplasmAttributeValueEntity> searchQuery = new SearchQueryBuilder<GermplasmAttributeValueEntity>(
 				GermplasmAttributeValueEntity.class)

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import io.swagger.model.core.SortOrder;
 import io.swagger.model.germ.*;
 import jakarta.validation.Valid;
 
@@ -137,7 +138,7 @@ public class GermplasmService {
 					"*institute.instituteCode");
 		}
 
-				searchQuery.withExRefs(request.getExternalReferenceIDs(), request.getExternalReferenceSources())
+		searchQuery.withExRefs(request.getExternalReferenceIDs(), request.getExternalReferenceSources())
 				.appendList(request.getAccessionNumbers(), "accessionNumber")
 				.appendList(request.getCollections(), "collection")
 				.appendList(request.getCommonCropNames(), "crop.cropName").appendList(request.getGermplasmDbIds(), "id")

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -4,7 +4,6 @@ import java.math.BigDecimal;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import io.swagger.model.core.SortOrder;
 import io.swagger.model.germ.*;
 import jakarta.validation.Valid;
 
@@ -28,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -109,8 +107,57 @@ public class GermplasmService {
 		return germplasms;
 	}
 
+	public List<Germplasm> findGermplasmWithoutPaging(@Valid GermplasmSearchRequest request) {
+		List<GermplasmEntity> entities = findGermplasmEntitiesWithoutPaging(request);
+		return entities.stream().map(this::convertFromEntity).collect(Collectors.toList());
+	}
+
 	public Page<GermplasmEntity> findGermplasmEntities(@Valid GermplasmSearchRequest request, Metadata metadata) {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
+
+		SearchQueryBuilder<GermplasmEntity> searchQuery = buildGermplasmSearchQuery(request);
+
+		// First run the query without the fetching all the entities, grabbing the IDs only and paginating and sorting them.
+		Page<GermplasmEntity> germs = germplasmRepository.findAllBySearchPaginatingWithFetches(searchQuery, pageReq);
+
+		// Hopefully this retains insertion order in the page?
+		List<String> ids = germs.map(BrAPIBaseEntity::getId).toList();
+
+		if (!germs.isEmpty()) {
+			// If records were found, iterate through the rest of the lazyily loaded collections of the GermplasmEntity
+			// and LEFT JOIN FETCH all of them.
+			log.debug("Fetching xrefs");
+			fetchXrefs(ids, germs);
+			log.debug("fetching attributes");
+			fetchAttributes(ids, germs);
+			log.debug("fetching donors");
+			fetchDonors(ids, germs);
+			log.debug("fetching origins");
+			fetchOrigin(ids, germs);
+			log.debug("fetching institutes");
+			fetchInstitutes(ids, germs);
+			log.debug("fetching taxons");
+			fetchTaxons(ids, germs);
+			log.debug("fetching storage codes");
+			fetchStorageCodes(ids, germs);
+			log.debug("fetching pedigree edges");
+			fetchPedigreeEdges(ids, germs);
+		}
+		return germs;
+	}
+
+	public List<GermplasmEntity> findGermplasmEntitiesWithoutPaging(@Valid GermplasmSearchRequest request) {
+		SearchQueryBuilder<GermplasmEntity> searchQuery = buildGermplasmSearchQuery(request);
+
+		List<GermplasmEntity>  germs = germplasmRepository.findAllBySearch(searchQuery);
+
+		if (!germs.isEmpty()) {
+			fetchRemainingGermCollectionsUsingQuery(searchQuery, germs);
+		}
+		return germs;
+	}
+
+	private SearchQueryBuilder<GermplasmEntity> buildGermplasmSearchQuery(GermplasmSearchRequest request) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
 		searchQuery.leftJoinFetch("synonyms", "synonyms")
@@ -149,37 +196,21 @@ public class GermplasmService {
 				.appendList(request.getGenus(), "genus").appendList(request.getSpecies(), "species")
 				.appendNamesList(request.getBinomialNames(), "genus", "genus", "species")
 				.appendList(request.getFamilyCodes(), "familyCode");
-
-		Page<UUID> page = germplasmRepository.findAllBySearchIdsOnly(searchQuery, pageReq);
-
-		Page<GermplasmEntity>  germs = germplasmRepository.findAllBySearchNoPage(searchQuery, page, pageReq);
-
-		if (!page.isEmpty()) {
-			log.debug("Fetching xrefs");
-			fetchXrefs(page, germs);
-			log.debug("fetching attributes");
-			fetchAttributes(page, germs);
-			log.debug("fetching donors");
-			fetchDonors(page, germs);
-			log.debug("fetching origins");
-			fetchOrigin(page, germs);
-			log.debug("fetching institutes");
-			fetchInstitutes(page, germs);
-			log.debug("fetching taxons");
-			fetchTaxons(page, germs);
-			log.debug("fetching storage codes");
-			fetchStorageCodes(page, germs);
-			log.debug("fetching pedigree edges");
-			fetchPedigreeEdges(page, germs);
-		}
-		return germs;
+		return searchQuery;
 	}
 
-	private void fetchXrefs(Page<UUID> page, Page<GermplasmEntity> germEntities) {
-		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(GermplasmEntity.class);
-		searchQuery.leftJoinFetch("externalReferences", "externalReferences");
+	// TODO: These left join fetch methods could be optimized a bit by guaranteeing a search on the same sort, because if the fetched
+	// TODO: list comes back with the same number of elements as the entities that come in, the two entity lists are in the exact same order.
+	// TODO: Therefore no need to store a map and can just iterate through both at the same time O(n).
 
-		Page<GermplasmEntity> xrefs = germplasmRepository.findAllBySearchNoPage(searchQuery, page, PageRequest.of(0, page.getSize()));
+	// TODO: Revisit when sortBy is added to GermplasmSearchRequest and we can pass through a sortBy value.
+	private void fetchXrefs(List<String> ids, Page<GermplasmEntity> germEntities) {
+		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<>(GermplasmEntity.class);
+
+		searchQuery.leftJoinFetch("externalReferences", "externalReferences")
+				.appendIds(ids);
+
+		List<GermplasmEntity> xrefs = germplasmRepository.findAllBySearch(searchQuery);
 
 		Map<String, List<ExternalReferenceEntity>> xrefByEntity = new HashMap<>();
 		xrefs.forEach(entity -> xrefByEntity.put(entity.getId(), entity.getExternalReferences()));
@@ -187,14 +218,13 @@ public class GermplasmService {
 		germEntities.forEach(entity -> entity.setExternalReferences(xrefByEntity.get(entity.getId().toString())));
 	}
 
-	private void fetchAttributes(Page<UUID> page, Page<GermplasmEntity> germEntities) {
+	private void fetchAttributes(List<String> ids, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
-		searchQuery.leftJoinFetch("attributes", "attributes");
+		searchQuery.leftJoinFetch("attributes", "attributes")
+				.appendIds(ids);
 
-		Page<GermplasmEntity> attributes = germplasmRepository.findAllBySearchNoPage(searchQuery,
-				page,
-				PageRequest.of(0, page.getSize()));
+		List<GermplasmEntity> attributes = germplasmRepository.findAllBySearch(searchQuery);
 
 		Map<String, List<GermplasmAttributeValueEntity>> attributesByGerm = new HashMap<>();
 		attributes.forEach(germ -> attributesByGerm.put(germ.getId(), germ.getAttributes()));
@@ -202,14 +232,13 @@ public class GermplasmService {
 		germEntities.forEach(germ -> germ.setAttributes(attributesByGerm.get(germ.getId().toString())));
 	}
 
-	private void fetchDonors(Page<UUID> page, Page<GermplasmEntity> germEntities) {
+	private void fetchDonors(List<String> ids, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
-		searchQuery.leftJoinFetch("donors", "donors");
+		searchQuery.leftJoinFetch("donors", "donors")
+				.appendIds(ids);
 
-		Page<GermplasmEntity> donors = germplasmRepository.findAllBySearchNoPage(searchQuery,
-				page,
-				PageRequest.of(0, page.getSize()));
+		List<GermplasmEntity> donors = germplasmRepository.findAllBySearch(searchQuery);
 
 		Map<String, List<DonorEntity>> donorsByGerm = new HashMap<>();
 		donors.forEach(germ -> donorsByGerm.put(germ.getId(), germ.getDonors()));
@@ -217,14 +246,13 @@ public class GermplasmService {
 		germEntities.forEach(germ -> germ.setDonors(donorsByGerm.get(germ.getId().toString())));
 	}
 
-	private void fetchOrigin(Page<UUID> page, Page<GermplasmEntity> germEntities) {
+	private void fetchOrigin(List<String> ids, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
-		searchQuery.leftJoinFetch("germplasmOrigin", "germplasmOrigin");
+		searchQuery.leftJoinFetch("germplasmOrigin", "germplasmOrigin")
+				.appendIds(ids);
 
-		Page<GermplasmEntity> origins = germplasmRepository.findAllBySearchNoPage(searchQuery,
-				page,
-				PageRequest.of(0, page.getSize()));
+		List<GermplasmEntity> origins = germplasmRepository.findAllBySearch(searchQuery);
 
 		Map<String, List<GermplasmOriginEntity>> originsByGerm = new HashMap<>();
 		origins.forEach(germ -> originsByGerm.put(germ.getId(), germ.getGermplasmOrigin()));
@@ -232,14 +260,13 @@ public class GermplasmService {
 		germEntities.forEach(germ -> germ.setGermplasmOrigin(originsByGerm.get(germ.getId().toString())));
 	}
 
-	private void fetchInstitutes(Page<UUID> page, Page<GermplasmEntity> germEntities) {
+	private void fetchInstitutes(List<String> ids, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
-		searchQuery.leftJoinFetch("institutes", "institutes");
+		searchQuery.leftJoinFetch("institutes", "institutes")
+				.appendIds(ids);
 
-		Page<GermplasmEntity> institutes = germplasmRepository.findAllBySearchNoPage(searchQuery,
-				page,
-				PageRequest.of(0, page.getSize()));
+		List<GermplasmEntity> institutes = germplasmRepository.findAllBySearch(searchQuery);
 
 		Map<String, List<GermplasmInstituteEntity>> institutesByGerm = new HashMap<>();
 		institutes.forEach(germ -> institutesByGerm.put(germ.getId(), germ.getInstitutes()));
@@ -247,14 +274,13 @@ public class GermplasmService {
 		germEntities.forEach(germ -> germ.setInstitutes(institutesByGerm.get(germ.getId().toString())));
 	}
 
-	private void fetchTaxons(Page<UUID> page, Page<GermplasmEntity> germEntities) {
+	private void fetchTaxons(List<String> ids, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
-		searchQuery.leftJoinFetch("taxonIds", "taxonIds");
+		searchQuery.leftJoinFetch("taxonIds", "taxonIds")
+				.appendIds(ids);
 
-		Page<GermplasmEntity> taxonIds = germplasmRepository.findAllBySearchNoPage(searchQuery,
-				page,
-				PageRequest.of(0, page.getSize()));
+		List<GermplasmEntity> taxonIds = germplasmRepository.findAllBySearch(searchQuery);
 
 		Map<String, List<TaxonEntity>> taxonIdsByGerm = new HashMap<>();
 		taxonIds.forEach(germ -> taxonIdsByGerm.put(germ.getId(), germ.getTaxonIds()));
@@ -262,14 +288,13 @@ public class GermplasmService {
 		germEntities.forEach(germ -> germ.setTaxonIds(taxonIdsByGerm.get(germ.getId().toString())));
 	}
 
-	private void fetchStorageCodes(Page<UUID> page, Page<GermplasmEntity> germEntities) {
+	private void fetchStorageCodes(List<String> ids, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
-		searchQuery.leftJoinFetch("typeOfGermplasmStorageCode", "typeOfGermplasmStorageCode");
+		searchQuery.leftJoinFetch("typeOfGermplasmStorageCode", "typeOfGermplasmStorageCode")
+				.appendIds(ids);
 
-		Page<GermplasmEntity> storageCodes = germplasmRepository.findAllBySearchNoPage(searchQuery,
-				page,
-				PageRequest.of(0, page.getSize()));
+		List<GermplasmEntity> storageCodes = germplasmRepository.findAllBySearch(searchQuery);
 
 		Map<String, List<GermplasmStorageTypesEnum>> storageCodesByGerm = new HashMap<>();
 		storageCodes.forEach(germ -> storageCodesByGerm.put(germ.getId(), germ.getTypeOfGermplasmStorageCode()));
@@ -277,17 +302,16 @@ public class GermplasmService {
 		germEntities.forEach(germ -> germ.setTypeOfGermplasmStorageCode(storageCodesByGerm.get(germ.getId().toString())));
 	}
 
-	private void fetchPedigreeEdges(Page<UUID> page, Page<GermplasmEntity> germEntities) {
+	private void fetchPedigreeEdges(List<String> ids, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
 		searchQuery.leftJoinFetch("pedigree", "pedigree")
 				   .leftJoinFetch("*pedigree.crossingProject", "crossingProject")
 				   .leftJoinFetch("*pedigree.edges", "pedigreeEdges")
-				   .leftJoinFetch("*pedigreeEdges.conncetedNode", "connectedNode");
+				   .leftJoinFetch("*pedigreeEdges.conncetedNode", "connectedNode")
+				   .appendIds(ids);
 
-		Page<GermplasmEntity> pedigree = germplasmRepository.findAllBySearchNoPage(searchQuery,
-				page,
-				PageRequest.of(0, page.getSize()));
+		List<GermplasmEntity> pedigree = germplasmRepository.findAllBySearch(searchQuery);
 
 		Map<String, PedigreeNodeEntity> pedigreeByGerm = new HashMap<>();
 		pedigree.forEach(germ -> pedigreeByGerm.put(germ.getId(), germ.getPedigree()));
@@ -296,6 +320,126 @@ public class GermplasmService {
 			germ.setPedigree(pedigreeByGerm.get(germ.getId().toString()));
 		});
 	}
+
+	private void fetchRemainingGermCollectionsUsingQuery(SearchQueryBuilder<GermplasmEntity> searchQuery, List<GermplasmEntity> germEntities) {
+		// Remove unused left join fetches from the base query
+		searchQuery.removeLeftJoinFetch("synonyms", "synonyms")
+				.removeLeftJoinFetch("breedingMethod", "breedingMethod")
+				.removeLeftJoinFetch("crop", "crop")
+				.removeLeftJoinFetch("pedigree", "pedigree")
+				.removeLeftJoinFetch("*pedigree.crossingProject", "crossingProject");
+		// Fetch xrefs
+		log.debug("Fetching xrefs");
+		searchQuery.leftJoinFetch("externalReferences",
+				"externalReferences");
+
+		// TODO: This method doesn't need to utilize a method that returns a page.
+		List<GermplasmEntity> xrefs = germplasmRepository.findAllBySearch(searchQuery);
+
+		Map<String, List<ExternalReferenceEntity>> xrefByEntity = new HashMap<>();
+		xrefs.forEach(entity -> xrefByEntity.put(entity.getId().toString(), entity.getExternalReferences()));
+
+		germEntities.forEach(entity -> entity.setExternalReferences(xrefByEntity.get(entity.getId().toString())));
+		// Fetch attributes
+		log.debug("fetching attributes");
+		searchQuery.removeAndReplaceLeftJoinFetch("attributes",
+				"attributes",
+				"externalReferences",
+				"externalReferences");
+
+		List<GermplasmEntity> attributes = germplasmRepository.findAllBySearch(searchQuery);
+
+		Map<String, List<GermplasmAttributeValueEntity>> attributesByGerm = new HashMap<>();
+		attributes.forEach(germ -> attributesByGerm.put(germ.getId().toString(), germ.getAttributes()));
+
+		germEntities.forEach(germ -> germ.setAttributes(attributesByGerm.get(germ.getId().toString())));
+		// Fetch donors
+		log.debug("fetching donors");
+		searchQuery.removeAndReplaceLeftJoinFetch("donors",
+				"donors",
+				"attributes",
+				"attributes");
+
+		List<GermplasmEntity> donors = germplasmRepository.findAllBySearch(searchQuery);
+
+		Map<String, List<DonorEntity>> donorsByGerm = new HashMap<>();
+		donors.forEach(germ -> donorsByGerm.put(germ.getId().toString(), germ.getDonors()));
+
+		germEntities.forEach(germ -> germ.setDonors(donorsByGerm.get(germ.getId().toString())));
+		// Fetch origins
+		log.debug("fetching origins");
+		searchQuery.removeAndReplaceLeftJoinFetch("germplasmOrigin",
+				"germplasmOrigin",
+				"donors",
+				"donors");
+
+
+		List<GermplasmEntity> origins = germplasmRepository.findAllBySearch(searchQuery);
+
+		Map<String, List<GermplasmOriginEntity>> originsByGerm = new HashMap<>();
+		origins.forEach(germ -> originsByGerm.put(germ.getId().toString(), germ.getGermplasmOrigin()));
+
+		germEntities.forEach(germ -> germ.setGermplasmOrigin(originsByGerm.get(germ.getId().toString())));
+
+		// Fetch institutes
+		log.debug("fetching institutes");
+		searchQuery.removeAndReplaceLeftJoinFetch("institutes",
+				"institutes",
+				"germplasmOrigin",
+				"germplasmOrigin");
+
+		List<GermplasmEntity> institutes = germplasmRepository.findAllBySearch(searchQuery);
+
+		Map<String, List<GermplasmInstituteEntity>> institutesByGerm = new HashMap<>();
+		institutes.forEach(germ -> institutesByGerm.put(germ.getId().toString(), germ.getInstitutes()));
+
+		germEntities.forEach(germ -> germ.setInstitutes(institutesByGerm.get(germ.getId().toString())));
+
+		// Fetch taxons
+		log.debug("fetching taxons");
+		searchQuery.removeAndReplaceLeftJoinFetch("taxonIds",
+				"taxonIds",
+				"institutes",
+				"institutes");
+
+		List<GermplasmEntity> taxonIds = germplasmRepository.findAllBySearch(searchQuery);
+
+		Map<String, List<TaxonEntity>> taxonIdsByGerm = new HashMap<>();
+		taxonIds.forEach(germ -> taxonIdsByGerm.put(germ.getId().toString(), germ.getTaxonIds()));
+
+		germEntities.forEach(germ -> germ.setTaxonIds(taxonIdsByGerm.get(germ.getId().toString())));
+		// Fetch storage codes
+		log.debug("fetching storage codes");
+		searchQuery.removeAndReplaceLeftJoinFetch("typeOfGermplasmStorageCode",
+				"typeOfGermplasmStorageCode",
+				"taxonIds",
+				"taxonIds");
+
+		List<GermplasmEntity> storageCodes = germplasmRepository.findAllBySearch(searchQuery);
+
+		Map<String, List<GermplasmStorageTypesEnum>> storageCodesByGerm = new HashMap<>();
+		storageCodes.forEach(germ -> storageCodesByGerm.put(germ.getId().toString(), germ.getTypeOfGermplasmStorageCode()));
+
+		germEntities.forEach(germ -> germ.setTypeOfGermplasmStorageCode(storageCodesByGerm.get(germ.getId().toString())));
+		// Fetch pedigree edges
+		log.debug("fetching pedigree edges");
+		searchQuery.removeAndReplaceLeftJoinFetch("pedigree",
+						"pedigree",
+						"typeOfGermplasmStorageCode",
+						"typeOfGermplasmStorageCode")
+				.leftJoinFetch("*pedigree.crossingProject", "crossingProject")
+				.leftJoinFetch("*pedigree.edges", "pedigreeEdges")
+				.leftJoinFetch("*pedigreeEdges.conncetedNode", "connectedNode");
+
+		List<GermplasmEntity> pedigree = germplasmRepository.findAllBySearch(searchQuery);
+
+		Map<String, PedigreeNodeEntity> pedigreeByGerm = new HashMap<>();
+		pedigree.forEach(germ -> pedigreeByGerm.put(germ.getId().toString(), germ.getPedigree()));
+
+		germEntities.forEach(germ -> {
+			germ.setPedigree(pedigreeByGerm.get(germ.getId().toString()));
+		});
+	};
 
 	public Germplasm getGermplasm(String germplasmDbId) throws BrAPIServerException {
 		return convertFromEntity(getGermplasmEntity(germplasmDbId, HttpStatus.NOT_FOUND));

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -58,7 +58,8 @@ public class GermplasmService {
 			String accessionNumber, String collection, String binomialName, String genus, String species,
 			String trialDbId, String studyDbId, String synonym, String parentDbId, String progenyDbId,
 			String commonCropName, String programDbId, String externalReferenceId, String externalReferenceID,
-			String externalReferenceSource, Metadata metadata) {
+			String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 
 		GermplasmSearchRequest request = new GermplasmSearchRequest();
 		if (germplasmPUI != null)
@@ -97,7 +98,8 @@ public class GermplasmService {
 		return findGermplasm(request, metadata);
 	}
 
-	public List<Germplasm> findGermplasm(@Valid GermplasmSearchRequest request, Metadata metadata) {
+	public List<Germplasm> findGermplasm(@Valid GermplasmSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		log.debug("starting germplasm search");
 		Page<GermplasmEntity> page = findGermplasmEntities(request, metadata);
 		log.debug("germplasm search complete, converting germplasm entities");
@@ -112,7 +114,8 @@ public class GermplasmService {
 		return entities.stream().map(this::convertFromEntity).collect(Collectors.toList());
 	}
 
-	public Page<GermplasmEntity> findGermplasmEntities(@Valid GermplasmSearchRequest request, Metadata metadata) {
+	public Page<GermplasmEntity> findGermplasmEntities(@Valid GermplasmSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 
 		SearchQueryBuilder<GermplasmEntity> searchQuery = buildGermplasmSearchQuery(request);
@@ -124,7 +127,7 @@ public class GermplasmService {
 		List<String> ids = germs.map(BrAPIBaseEntity::getId).toList();
 
 		if (!germs.isEmpty()) {
-			// If records were found, iterate through the rest of the lazyily loaded collections of the GermplasmEntity
+			// If records were found, iterate through the rest of the lazily loaded collections of the GermplasmEntity
 			// and LEFT JOIN FETCH all of them.
 			log.debug("Fetching xrefs");
 			fetchXrefs(ids, germs);
@@ -651,7 +654,8 @@ public class GermplasmService {
 		}
 	}
 
-	public GermplasmEntity findByUnknownIdentity(String germplasmStr) {
+	public GermplasmEntity findByUnknownIdentity(String germplasmStr)
+		throws BrAPIServerException {
 		List<String> germplasmList = Arrays.asList(germplasmStr);
 		Metadata metadata = new Metadata().pagination(new IndexPagination());
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -137,7 +137,7 @@ public class GermplasmService {
 					"*institute.instituteCode");
 		}
 
-		searchQuery.withExRefs(request.getExternalReferenceIDs(), request.getExternalReferenceSources())
+				searchQuery.withExRefs(request.getExternalReferenceIDs(), request.getExternalReferenceSources())
 				.appendList(request.getAccessionNumbers(), "accessionNumber")
 				.appendList(request.getCollections(), "collection")
 				.appendList(request.getCommonCropNames(), "crop.cropName").appendList(request.getGermplasmDbIds(), "id")
@@ -149,146 +149,150 @@ public class GermplasmService {
 				.appendNamesList(request.getBinomialNames(), "genus", "genus", "species")
 				.appendList(request.getFamilyCodes(), "familyCode");
 
-		Page<GermplasmEntity> page = germplasmRepository.findAllBySearch(searchQuery, pageReq);
+		Page<UUID> page = germplasmRepository.findAllBySearchIdsOnly(searchQuery, pageReq);
 
-		if(!page.isEmpty()) {
-			log.debug("fetching xrefs");
-			fetchXrefs(page);
+		Page<GermplasmEntity>  germs = germplasmRepository.findAllBySearchNoPage(searchQuery, page, pageReq);
+
+		if (!page.isEmpty()) {
+			log.debug("Fetching xrefs");
+			fetchXrefs(page, germs);
 			log.debug("fetching attributes");
-			fetchAttributes(page);
+			fetchAttributes(page, germs);
 			log.debug("fetching donors");
-			fetchDonors(page);
+			fetchDonors(page, germs);
 			log.debug("fetching origins");
-			fetchOrigin(page);
+			fetchOrigin(page, germs);
 			log.debug("fetching institutes");
-			fetchInstitutes(page);
+			fetchInstitutes(page, germs);
 			log.debug("fetching taxons");
-			fetchTaxons(page);
+			fetchTaxons(page, germs);
 			log.debug("fetching storage codes");
-			fetchStorageCodes(page);
+			fetchStorageCodes(page, germs);
 			log.debug("fetching pedigree edges");
-			fetchPedigreeEdges(page);
+			fetchPedigreeEdges(page, germs);
 		}
-
-		return page;
+		return germs;
 	}
 
-	private void fetchXrefs(Page<GermplasmEntity> page) {
+	private void fetchXrefs(Page<UUID> page, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(GermplasmEntity.class);
-		searchQuery.leftJoinFetch("externalReferences", "externalReferences")
-				.leftJoinFetch("pedigree", "pedigree")
-				   .appendList(page.stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()), "id");
+		searchQuery.leftJoinFetch("externalReferences", "externalReferences");
 
-		Page<GermplasmEntity> xrefs = germplasmRepository.findAllBySearch(searchQuery, PageRequest.of(0, page.getSize()));
+		Page<GermplasmEntity> xrefs = germplasmRepository.findAllBySearchNoPage(searchQuery, page, PageRequest.of(0, page.getSize()));
 
 		Map<String, List<ExternalReferenceEntity>> xrefByEntity = new HashMap<>();
 		xrefs.forEach(entity -> xrefByEntity.put(entity.getId(), entity.getExternalReferences()));
 
-		page.forEach(entity -> entity.setExternalReferences(xrefByEntity.get(entity.getId())));
+		germEntities.forEach(entity -> entity.setExternalReferences(xrefByEntity.get(entity.getId().toString())));
 	}
 
-	private void fetchAttributes(Page<GermplasmEntity> page) {
+	private void fetchAttributes(Page<UUID> page, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
-		searchQuery.leftJoinFetch("attributes", "attributes")
-				   .appendList(page.stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()), "id");
+		searchQuery.leftJoinFetch("attributes", "attributes");
 
-		Page<GermplasmEntity> attributes = germplasmRepository.findAllBySearch(searchQuery, PageRequest.of(0, page.getSize()));
+		Page<GermplasmEntity> attributes = germplasmRepository.findAllBySearchNoPage(searchQuery,
+				page,
+				PageRequest.of(0, page.getSize()));
 
 		Map<String, List<GermplasmAttributeValueEntity>> attributesByGerm = new HashMap<>();
 		attributes.forEach(germ -> attributesByGerm.put(germ.getId(), germ.getAttributes()));
 
-		page.forEach(germ -> germ.setAttributes(attributesByGerm.get(germ.getId())));
+		germEntities.forEach(germ -> germ.setAttributes(attributesByGerm.get(germ.getId().toString())));
 	}
 
-	private void fetchDonors(Page<GermplasmEntity> page) {
+	private void fetchDonors(Page<UUID> page, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
-		searchQuery.leftJoinFetch("donors", "donors")
-				   .appendList(page.stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()), "id");
+		searchQuery.leftJoinFetch("donors", "donors");
 
-		Page<GermplasmEntity> donors = germplasmRepository.findAllBySearch(searchQuery, PageRequest.of(0, page.getSize()));
+		Page<GermplasmEntity> donors = germplasmRepository.findAllBySearchNoPage(searchQuery,
+				page,
+				PageRequest.of(0, page.getSize()));
 
 		Map<String, List<DonorEntity>> donorsByGerm = new HashMap<>();
 		donors.forEach(germ -> donorsByGerm.put(germ.getId(), germ.getDonors()));
 
-		page.forEach(germ -> germ.setDonors(donorsByGerm.get(germ.getId())));
+		germEntities.forEach(germ -> germ.setDonors(donorsByGerm.get(germ.getId().toString())));
 	}
 
-	private void fetchOrigin(Page<GermplasmEntity> page) {
+	private void fetchOrigin(Page<UUID> page, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
-		searchQuery.leftJoinFetch("germplasmOrigin", "germplasmOrigin")
-				   .appendList(page.stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()), "id");
+		searchQuery.leftJoinFetch("germplasmOrigin", "germplasmOrigin");
 
-		Page<GermplasmEntity> origins = germplasmRepository.findAllBySearch(searchQuery, PageRequest.of(0, page.getSize()));
+		Page<GermplasmEntity> origins = germplasmRepository.findAllBySearchNoPage(searchQuery,
+				page,
+				PageRequest.of(0, page.getSize()));
 
 		Map<String, List<GermplasmOriginEntity>> originsByGerm = new HashMap<>();
 		origins.forEach(germ -> originsByGerm.put(germ.getId(), germ.getGermplasmOrigin()));
 
-		page.forEach(germ -> germ.setGermplasmOrigin(originsByGerm.get(germ.getId())));
+		germEntities.forEach(germ -> germ.setGermplasmOrigin(originsByGerm.get(germ.getId().toString())));
 	}
 
-	private void fetchInstitutes(Page<GermplasmEntity> page) {
+	private void fetchInstitutes(Page<UUID> page, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
-		searchQuery.leftJoinFetch("institutes", "institutes")
-				   .appendList(page.stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()), "id");
+		searchQuery.leftJoinFetch("institutes", "institutes");
 
-		Page<GermplasmEntity> institutes = germplasmRepository.findAllBySearch(searchQuery, PageRequest.of(0, page.getSize()));
+		Page<GermplasmEntity> institutes = germplasmRepository.findAllBySearchNoPage(searchQuery,
+				page,
+				PageRequest.of(0, page.getSize()));
 
 		Map<String, List<GermplasmInstituteEntity>> institutesByGerm = new HashMap<>();
 		institutes.forEach(germ -> institutesByGerm.put(germ.getId(), germ.getInstitutes()));
 
-		page.forEach(germ -> germ.setInstitutes(institutesByGerm.get(germ.getId())));
+		germEntities.forEach(germ -> germ.setInstitutes(institutesByGerm.get(germ.getId().toString())));
 	}
 
-	private void fetchTaxons(Page<GermplasmEntity> page) {
+	private void fetchTaxons(Page<UUID> page, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
-		searchQuery.leftJoinFetch("taxonIds", "taxonIds")
-				   .appendList(page.stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()), "id");
+		searchQuery.leftJoinFetch("taxonIds", "taxonIds");
 
-		Page<GermplasmEntity> taxonIds = germplasmRepository.findAllBySearch(searchQuery, PageRequest.of(0, page.getSize()));
+		Page<GermplasmEntity> taxonIds = germplasmRepository.findAllBySearchNoPage(searchQuery,
+				page,
+				PageRequest.of(0, page.getSize()));
 
 		Map<String, List<TaxonEntity>> taxonIdsByGerm = new HashMap<>();
 		taxonIds.forEach(germ -> taxonIdsByGerm.put(germ.getId(), germ.getTaxonIds()));
 
-		page.forEach(germ -> germ.setTaxonIds(taxonIdsByGerm.get(germ.getId())));
+		germEntities.forEach(germ -> germ.setTaxonIds(taxonIdsByGerm.get(germ.getId().toString())));
 	}
 
-	private void fetchStorageCodes(Page<GermplasmEntity> page) {
+	private void fetchStorageCodes(Page<UUID> page, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
-		searchQuery.leftJoinFetch("typeOfGermplasmStorageCode", "typeOfGermplasmStorageCode")
-				   .appendList(page.stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()), "id");
+		searchQuery.leftJoinFetch("typeOfGermplasmStorageCode", "typeOfGermplasmStorageCode");
 
-		Page<GermplasmEntity> storageCodes = germplasmRepository.findAllBySearch(searchQuery, PageRequest.of(0, page.getSize()));
+		Page<GermplasmEntity> storageCodes = germplasmRepository.findAllBySearchNoPage(searchQuery,
+				page,
+				PageRequest.of(0, page.getSize()));
 
 		Map<String, List<GermplasmStorageTypesEnum>> storageCodesByGerm = new HashMap<>();
 		storageCodes.forEach(germ -> storageCodesByGerm.put(germ.getId(), germ.getTypeOfGermplasmStorageCode()));
 
-		page.forEach(germ -> germ.setTypeOfGermplasmStorageCode(storageCodesByGerm.get(germ.getId())));
+		germEntities.forEach(germ -> germ.setTypeOfGermplasmStorageCode(storageCodesByGerm.get(germ.getId().toString())));
 	}
 
-	private void fetchPedigreeEdges(Page<GermplasmEntity> page) {
+	private void fetchPedigreeEdges(Page<UUID> page, Page<GermplasmEntity> germEntities) {
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
 		searchQuery.leftJoinFetch("pedigree", "pedigree")
 				   .leftJoinFetch("*pedigree.crossingProject", "crossingProject")
 				   .leftJoinFetch("*pedigree.edges", "pedigreeEdges")
-				   .leftJoinFetch("*pedigreeEdges.conncetedNode", "connectedNode")
-				   .appendList(page.stream()
-								   .map(BrAPIBaseEntity::getId)
-								   .collect(Collectors.toList()), "id");
+				   .leftJoinFetch("*pedigreeEdges.conncetedNode", "connectedNode");
 
-		Page<GermplasmEntity> pedigree = germplasmRepository.findAllBySearch(searchQuery, PageRequest.of(0, page.getSize()));
+		Page<GermplasmEntity> pedigree = germplasmRepository.findAllBySearchNoPage(searchQuery,
+				page,
+				PageRequest.of(0, page.getSize()));
 
 		Map<String, PedigreeNodeEntity> pedigreeByGerm = new HashMap<>();
 		pedigree.forEach(germ -> pedigreeByGerm.put(germ.getId(), germ.getPedigree()));
 
-		page.forEach(germ -> {
-			germ.setPedigree(pedigreeByGerm.get(germ.getId()));
+		germEntities.forEach(germ -> {
+			germ.setPedigree(pedigreeByGerm.get(germ.getId().toString()));
 		});
 	}
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -154,7 +154,7 @@ public class PedigreeService {
 				.appendNamesList(request.getBinomialNames(), "germplasm.genus", "germplasm.genus", "germplasm.species")
 				.appendList(request.getFamilyCodes(), "familyCode");
 
-		Page<PedigreeNodeEntity> page = pedigreeRepository.findAllBySearch(searchQuery, pageReq);
+		Page<PedigreeNodeEntity> page = pedigreeRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 
 		List<PedigreeNodeEntity> filteredNodes = filterGenerations(request, page.getContent());
 
@@ -496,7 +496,7 @@ public class PedigreeService {
 			search.appendSingle(node.getGermplasmDbId(), "conncetedNode.germplasm.id");
 			search.appendEnum(PedigreeEdgeEntity.EdgeType.child, "edgeType");
 			Pageable defaultPageSize = PagingUtility.getPageRequest(new Metadata().pagination(new IndexPagination().pageSize(10000000)));
-			Page<PedigreeEdgeEntity> existingParentEdges = pedigreeEdgeRepository.findAllBySearch(search, defaultPageSize);
+			Page<PedigreeEdgeEntity> existingParentEdges = pedigreeEdgeRepository.findAllBySearchAndPaginate(search, defaultPageSize);
 
 			List<String> edgeIdsToDelete = new ArrayList<>();
 			edgeIdsToDelete.addAll(entity.getParentEdges().stream().map(e -> e.getId()).collect(Collectors.toList()));
@@ -519,7 +519,7 @@ public class PedigreeService {
 			search.appendSingle(node.getGermplasmDbId(), "conncetedNode.germplasm.id");
 			search.appendEnum(PedigreeEdgeEntity.EdgeType.parent, "edgeType");
 			Pageable defaultPageSize = PagingUtility.getPageRequest(new Metadata().pagination(new IndexPagination().pageSize(10000000)));
-			Page<PedigreeEdgeEntity> existingProgenyEdges = pedigreeEdgeRepository.findAllBySearch(search, defaultPageSize);
+			Page<PedigreeEdgeEntity> existingProgenyEdges = pedigreeEdgeRepository.findAllBySearchAndPaginate(search, defaultPageSize);
 
 			List<String> edgeIdsToDelete = new ArrayList<>();
 			edgeIdsToDelete.addAll(entity.getProgenyEdges().stream().map(e -> e.getId()).collect(Collectors.toList()));

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -65,7 +65,8 @@ public class PedigreeService {
 			String trialDbId, String studyDbId, String synonym, String commonCropName, String programDbId,
 			String externalReferenceId, String externalReferenceSource, Boolean includeParents, Boolean includeSiblings,
 			Boolean includeProgeny, Boolean includeFullTree, Integer pedigreeDepth, Integer progenyDepth,
-			Metadata metadata) {
+			Metadata metadata)
+		throws BrAPIServerException {
 
 		PedigreeSearchRequest request = new PedigreeSearchRequest();
 		if (germplasmPUI != null)
@@ -112,13 +113,15 @@ public class PedigreeService {
 		return findPedigree(request, metadata);
 	}
 
-	public List<PedigreeNode> findPedigree(PedigreeSearchRequest request, Metadata metadata) {
+	public List<PedigreeNode> findPedigree(PedigreeSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		List<PedigreeNodeEntity> page = findPedigreeEntities(request, metadata);
 		List<PedigreeNode> pedigreeNodes = convertFromEntities(page, request);
 		return pedigreeNodes;
 	}
 
-	public List<PedigreeNodeEntity> findPedigreeEntities(PedigreeSearchRequest request, Metadata metadata) {
+	public List<PedigreeNodeEntity> findPedigreeEntities(PedigreeSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<PedigreeNodeEntity> searchQuery = new SearchQueryBuilder<PedigreeNodeEntity>(
 				PedigreeNodeEntity.class);
@@ -305,7 +308,8 @@ public class PedigreeService {
 
 	}
 
-	private Map<String, PedigreeNodeEntity> getExistingPedigreeNodes(List<String> germplasmDbIds) {
+	private Map<String, PedigreeNodeEntity> getExistingPedigreeNodes(List<String> germplasmDbIds)
+		throws BrAPIServerException {
 		Map<String, PedigreeNodeEntity> nodesByGermplasm = new HashMap<>();
 
 		if (null != germplasmDbIds && !germplasmDbIds.isEmpty()) {
@@ -538,7 +542,8 @@ public class PedigreeService {
 		}
 	}
 
-	public PedigreeNode convertFromGermplasmToPedigree(Germplasm germplasm) {
+	public PedigreeNode convertFromGermplasmToPedigree(Germplasm germplasm)
+		throws BrAPIServerException {
 		PedigreeNode node = new PedigreeNode();
 
 		List<String> pedigreeList = new ArrayList<>();

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/SeedLotService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/SeedLotService.java
@@ -81,7 +81,7 @@ public class SeedLotService {
 			searchQuery = searchQuery.withExRefs(Arrays.asList(externalReferenceID),
 					Arrays.asList(externalReferenceSource));
 
-		Page<SeedLotEntity> page = seedLotRepository.findAllBySearch(searchQuery, pageReq);
+		Page<SeedLotEntity> page = seedLotRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<SeedLot> seedLots = page.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, page);
 		return seedLots;
@@ -165,7 +165,7 @@ public class SeedLotService {
 			searchQuery = searchQuery.withExRefs(Arrays.asList(externalReferenceID),
 					Arrays.asList(externalReferenceSource));
 
-		Page<SeedLotTransactionEntity> page = seedLotTransactionRepository.findAllBySearch(searchQuery, pageReq);
+		Page<SeedLotTransactionEntity> page = seedLotTransactionRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<SeedLotTransaction> transactions = page.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, page);
 		return transactions;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/SeedLotService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/SeedLotService.java
@@ -59,8 +59,9 @@ public class SeedLotService {
 	}
 
 	public List<SeedLot> findSeedLots(String seedLotDbId, String germplasmDbId, String germplasmName, String crossDbId,
-			String crossName, String commonCropName, String programDbId, String externalReferenceId,
-			String externalReferenceID, String externalReferenceSource, Metadata metadata) {
+			String crossName, String commonCropName, String programDbId,
+									  String externalReferenceID, String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<SeedLotEntity> searchQuery = new SearchQueryBuilder<SeedLotEntity>(SeedLotEntity.class);
 
@@ -131,16 +132,17 @@ public class SeedLotService {
 			String transactionDirection, Metadata metadata) throws BrAPIServerException {
 		SeedLot seedLot = getSeedLot(seedLotDbId);
 		if (seedLot != null) {
-			return findSeedLotTransactions(transactionDbId, seedLotDbId, null, null, null, null, null, null, null, null,
+			return findSeedLotTransactions(transactionDbId, seedLotDbId, null, null, null, null, null, null, null,
 					null, metadata);
 		}
 		return null;
 	}
 
 	public List<SeedLotTransaction> findSeedLotTransactions(String transactionDbId, String seedLotDbId,
-			String germplasmDbId, String germplasmName, String crossDbId, String crossName, String commonCropName,
-			String programDbId, String externalReferenceId, String externalReferenceID, String externalReferenceSource,
-			Metadata metadata) {
+															String germplasmDbId, String germplasmName, String crossDbId, String crossName, String commonCropName,
+															String programDbId, String externalReferenceID, String externalReferenceSource,
+															Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<SeedLotTransactionEntity> searchQuery = new SearchQueryBuilder<SeedLotTransactionEntity>(
 				SeedLotTransactionEntity.class);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/EventService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/EventService.java
@@ -45,7 +45,7 @@ public class EventService {
 					"*dateOccured");
 		}
 
-		Page<EventEntity> page = eventRepository.findAllBySearch(searchQuery, pageReq);
+		Page<EventEntity> page = eventRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		List<Event> crossingProjects = page.map(this::convertFromEntity).getContent();
 		PagingUtility.calculateMetaData(metadata, page);
 		return crossingProjects;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/EventService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/EventService.java
@@ -3,6 +3,7 @@ package org.brapi.test.BrAPITestServer.service.pheno;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
 import org.brapi.test.BrAPITestServer.model.entity.pheno.EventEntity;
 import org.brapi.test.BrAPITestServer.repository.pheno.EventRepository;
 import org.brapi.test.BrAPITestServer.service.DateUtility;
@@ -29,7 +30,8 @@ public class EventService {
 	}
 
 	public List<Event> findEvents(String eventDbId, String studyDbId, String observationUnitDbId, String eventType,
-			OffsetDateTime dateRangeStart, OffsetDateTime dateRangeEnd, Metadata metadata) {
+			OffsetDateTime dateRangeStart, OffsetDateTime dateRangeEnd, Metadata metadata)
+		throws BrAPIServerException  {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<EventEntity> searchQuery = new SearchQueryBuilder<EventEntity>(EventEntity.class);
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ImageService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ImageService.java
@@ -86,7 +86,7 @@ public class ImageService {
 						"timeStamp")
 				.appendGeoJSONArea(request.getImageLocation());
 
-		Page<ImageEntity> imagePage = imageRepository.findAllBySearch(searchQuery, pageReq);
+		Page<ImageEntity> imagePage = imageRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		PagingUtility.calculateMetaData(metadata, imagePage);
 		return imagePage.getContent();
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ImageService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ImageService.java
@@ -42,7 +42,8 @@ public class ImageService {
 
 	public List<Image> findImages(String imageDbId, String imageName, String observationUnitDbId,
 			String observationDbId, String descriptiveOntologyTerm, String commonCropName, String programDbId,
-			String externalReferenceId, String externalReferenceID, String externalReferenceSource, Metadata metadata) {
+			String externalReferenceId, String externalReferenceID, String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 		ImageSearchRequest request = new ImageSearchRequest();
 		if (imageDbId != null)
 			request.addImageDbIdsItem(imageDbId);
@@ -64,7 +65,8 @@ public class ImageService {
 		return findImages(request, metadata);
 	}
 
-	public List<ImageEntity> findImageEntities(ImageSearchRequest request, Metadata metadata) {
+	public List<ImageEntity> findImageEntities(ImageSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<ImageEntity> searchQuery = new SearchQueryBuilder<ImageEntity>(ImageEntity.class);
 		if (request.getDescriptiveOntologyTerms() != null) {
@@ -91,7 +93,8 @@ public class ImageService {
 		return imagePage.getContent();
 	}
 
-	public List<Image> findImages(ImageSearchRequest request, Metadata metadata) {
+	public List<Image> findImages(ImageSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		List<ImageEntity> imagePage = findImageEntities(request, metadata);
 		List<Image> images = imagePage.stream().map(this::convertFromEntity).collect(Collectors.toList());
 		return images;
@@ -170,7 +173,8 @@ public class ImageService {
 		return bytes;
 	}
 
-	public List<String> deleteImages(ImageSearchRequest body, Metadata metadata) {
+	public List<String> deleteImages(ImageSearchRequest body, Metadata metadata)
+		throws BrAPIServerException {
 		List<String> deletedImageDbIds = new ArrayList<>();
 
 		if (body.getTotalParameterCount() > 0) {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/MethodService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/MethodService.java
@@ -43,7 +43,7 @@ public class MethodService {
 		}
 		searchQuery = searchQuery.appendSingle(methodDbId, "id").withExRefs(externalReferenceID,
 				externalReferenceSource);
-		Page<MethodEntity> methodPage = methodRepository.findAllBySearch(searchQuery, pageReq);
+		Page<MethodEntity> methodPage = methodRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		PagingUtility.calculateMetaData(metadata, methodPage);
 
 		List<Method> methods = methodPage.map(this::convertFromEntity).getContent();

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/MethodService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/MethodService.java
@@ -34,7 +34,8 @@ public class MethodService {
 
 	public List<Method> findMethods(String methodDbId, String observationVariableDbId, String ontologyDbId,
 			String commonCropName, String programDbId, String externalReferenceId, String externalReferenceID,
-			String externalReferenceSource, Metadata metadata) {
+			String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<MethodEntity> searchQuery = new SearchQueryBuilder<MethodEntity>(MethodEntity.class);
 		if (observationVariableDbId != null) {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationService.java
@@ -242,7 +242,7 @@ public class ObservationService {
 				.appendList(request.getTrialDbIds(), "trial.id").appendList(request.getTrialNames(), "trial.trialName");
 
 		log.debug("starting search");
-		Page<ObservationEntity> page = observationRepository.findAllBySearch(searchQuery, pageReq);
+		Page<ObservationEntity> page = observationRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		log.debug("search complete");
 
 		if(!page.isEmpty()) {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationService.java
@@ -148,7 +148,8 @@ public class ObservationService {
 		return findObservationsTable(obsRequest);
 	}
 
-	public ObservationTable findObservationsTable(ObservationSearchRequest obsRequest) {
+	public ObservationTable findObservationsTable(ObservationSearchRequest obsRequest)
+		throws BrAPIServerException {
 		Page<ObservationEntity> observations = findObservationEntities(obsRequest, null);
 
 		List<ObservationVariableEntity> variables = observations.stream().map(obs -> obs.getObservationVariable())
@@ -161,7 +162,8 @@ public class ObservationService {
 		return table;
 	}
 
-	public List<Observation> findObservations(@Valid ObservationSearchRequest request, Metadata metadata) {
+	public List<Observation> findObservations(@Valid ObservationSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Page<ObservationEntity> page = findObservationEntities(request, metadata);
 		log.debug("converting "+page.getSize()+" entities");
 		List<Observation> observations = page.map(this::convertFromEntity).getContent();
@@ -170,7 +172,8 @@ public class ObservationService {
 		return observations;
 	}
 
-	public Page<ObservationEntity> findObservationEntities(@Valid ObservationSearchRequest request, Metadata metadata) {
+	public Page<ObservationEntity> findObservationEntities(@Valid ObservationSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<ObservationEntity> searchQuery = new SearchQueryBuilder<ObservationEntity>(
 				ObservationEntity.class);
@@ -296,7 +299,8 @@ public class ObservationService {
 		return savedObservations;
 	}
 
-	public List<String> deleteObservations(ObservationSearchRequest body, Metadata metadata) {
+	public List<String> deleteObservations(ObservationSearchRequest body, Metadata metadata)
+		throws BrAPIServerException {
 		List<String> deletedObservationDbIds = new ArrayList<>();
 
 		if (body.getTotalParameterCount() > 0) {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitService.java
@@ -261,7 +261,7 @@ public class ObservationUnitService {
 				.appendList(request.getTrialNames(), "trial.trailName");
 
 		log.debug("Starting search");
-		Page<ObservationUnitEntity> page = observationUnitRepository.findAllBySearch(searchQuery, pageReq);
+		Page<ObservationUnitEntity> page = observationUnitRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		log.debug("Search complete");
 
 		if(!page.isEmpty()) {
@@ -278,7 +278,7 @@ public class ObservationUnitService {
 		searchQuery.leftJoinFetch("treatments", "treatments")
 				   .appendList(page.stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()), "id");
 
-		Page<ObservationUnitEntity> treatments = observationUnitRepository.findAllBySearch(searchQuery, PageRequest.of(0, page.getSize()));
+		Page<ObservationUnitEntity> treatments = observationUnitRepository.findAllBySearchAndPaginate(searchQuery, PageRequest.of(0, page.getSize()));
 
 		Map<String, List<TreatmentEntity>> treatmentsByOu = new HashMap<>();
 		treatments.forEach(ou -> treatmentsByOu.put(ou.getId(), ou.getTreatments()));
@@ -293,7 +293,7 @@ public class ObservationUnitService {
 				   .leftJoinFetch("*position.observationLevelRelationships", "observationLevelRelationships")
 				   .appendList(page.stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()), "id");
 
-		Page<ObservationUnitEntity> positions = observationUnitRepository.findAllBySearch(searchQuery, PageRequest.of(0, page.getSize()));
+		Page<ObservationUnitEntity> positions = observationUnitRepository.findAllBySearchAndPaginate(searchQuery, PageRequest.of(0, page.getSize()));
 
 		Map<String, ObservationUnitPositionEntity> positionByOu = new HashMap<>();
 		positions.forEach(ou -> positionByOu.put(ou.getId(), ou.getPosition()));

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitService.java
@@ -75,7 +75,8 @@ public class ObservationUnitService {
 			String observationUnitLevelCode, String observationUnitLevelRelationshipName,
 			String observationUnitLevelRelationshipOrder, String observationUnitLevelRelationshipCode,
 			String observationUnitLevelRelationshipDbId, String commonCropName, Boolean includeObservations,
-			String externalReferenceId, String externalReferenceID, String externalReferenceSource, Metadata metadata) {
+			String externalReferenceId, String externalReferenceID, String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 		ObservationUnitSearchRequest request = buildObservationUnitsSearchRequest(observationUnitDbId,
 				observationUnitName, germplasmDbId, studyDbId, locationDbId, trialDbId, programDbId, seasonDbId,
 				observationUnitLevelName, observationUnitLevelOrder, observationUnitLevelCode,
@@ -148,7 +149,8 @@ public class ObservationUnitService {
 			String seasonDbId, String observationLevel, String observationUnitLevelName,
 			String observationUnitLevelOrder, String observationUnitLevelCode,
 			String observationUnitLevelRelationshipName, String observationUnitLevelRelationshipOrder,
-			String observationUnitLevelRelationshipCode, String observationUnitLevelRelationshipDbId) {
+			String observationUnitLevelRelationshipCode, String observationUnitLevelRelationshipDbId)
+		throws BrAPIServerException {
 
 		ObservationUnitSearchRequest ouRequest = buildObservationUnitsSearchRequest(observationUnitDbId, null,
 				germplasmDbId, studyDbId, locationDbId, trialDbId, programDbId, seasonDbId, observationUnitLevelName,
@@ -169,7 +171,8 @@ public class ObservationUnitService {
 		return table;
 	}
 
-	public List<ObservationUnit> findObservationUnits(@Valid ObservationUnitSearchRequest request, Metadata metadata) {
+	public List<ObservationUnit> findObservationUnits(@Valid ObservationUnitSearchRequest request, Metadata metadata)
+		throws BrAPIServerException {
 		Page<ObservationUnitEntity> page = findObservationUnitEntities(request, metadata);
 
 		boolean includeObservations = request.isIncludeObservations() != null && request.isIncludeObservations();
@@ -191,7 +194,8 @@ public class ObservationUnitService {
 	}
 
 	public Page<ObservationUnitEntity> findObservationUnitEntities(@Valid ObservationUnitSearchRequest request,
-			Metadata metadata) {
+			Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<ObservationUnitEntity> searchQuery = new SearchQueryBuilder<ObservationUnitEntity>(
 				ObservationUnitEntity.class);
@@ -272,7 +276,8 @@ public class ObservationUnitService {
 		return page;
 	}
 
-	private void fetchTreatments(Page<ObservationUnitEntity> page) {
+	private void fetchTreatments(Page<ObservationUnitEntity> page)
+		throws BrAPIServerException {
 		SearchQueryBuilder<ObservationUnitEntity> searchQuery = new SearchQueryBuilder<ObservationUnitEntity>(
 				ObservationUnitEntity.class);
 		searchQuery.leftJoinFetch("treatments", "treatments")
@@ -286,7 +291,8 @@ public class ObservationUnitService {
 		page.forEach(ou -> ou.setTreatments(treatmentsByOu.get(ou.getId())));
 	}
 
-	private void fetchObsUnitLevelRelationships(Page<ObservationUnitEntity> page) {
+	private void fetchObsUnitLevelRelationships(Page<ObservationUnitEntity> page)
+		throws BrAPIServerException {
 		SearchQueryBuilder<ObservationUnitEntity> searchQuery = new SearchQueryBuilder<ObservationUnitEntity>(
 				ObservationUnitEntity.class);
 		searchQuery.leftJoinFetch("position", "position")
@@ -367,7 +373,8 @@ public class ObservationUnitService {
 	}
 
 	public List<ObservationUnitHierarchyLevel> findObservationLevels(String studyDbId, String trialDbId,
-			String programDbId, Metadata metadata) {
+			String programDbId, Metadata metadata)
+		throws BrAPIServerException {
 
 		List<ObservationUnitLevel> allLevels = Arrays.asList(ObservationUnitHierarchyLevelEnum.values()).stream()
 				.map(levelEnum -> {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationVariableService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationVariableService.java
@@ -68,7 +68,8 @@ public class ObservationVariableService {
 			String methodPUI, String scaleDbId, String scaleName, String scalePUI, String traitDbId, String traitName,
 			String traitPUI, String traitClass, String ontologyDbId, String commonCropName, String programDbId,
 			String trialDbId, String studyDbId, String externalReferenceId, String externalReferenceID,
-			String externalReferenceSource, Metadata metadata) {
+			String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 
 		ObservationVariableSearchRequest request = new ObservationVariableSearchRequest();
 
@@ -113,7 +114,8 @@ public class ObservationVariableService {
 	}
 
 	public List<ObservationVariable> findObservationVariables(ObservationVariableSearchRequest request,
-			Metadata metadata) {
+			Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<ObservationVariableEntity> searchQuery = new SearchQueryBuilder<ObservationVariableEntity>(
 				ObservationVariableEntity.class);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationVariableService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationVariableService.java
@@ -137,7 +137,7 @@ public class ObservationVariableService {
 				.appendEnumList(request.getDataTypes(), "scale.dataType");
 
 		log.debug("Starting variable search");
-		Page<ObservationVariableEntity> page = observationVariableRepository.findAllBySearch(searchQuery, pageReq);
+		Page<ObservationVariableEntity> page = observationVariableRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		log.debug("Variable search complete");
 
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ScaleService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ScaleService.java
@@ -48,7 +48,7 @@ public class ScaleService {
 		}
 		searchQuery = searchQuery.appendSingle(scaleDbId, "id").withExRefs(externalReferenceID,
 				externalReferenceSource);
-		Page<ScaleEntity> scalePage = scaleRepository.findAllBySearch(searchQuery, pageReq);
+		Page<ScaleEntity> scalePage = scaleRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		PagingUtility.calculateMetaData(metadata, scalePage);
 
 		List<Scale> scales = scalePage.map(this::convertFromEntity).getContent();

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ScaleService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ScaleService.java
@@ -39,11 +39,12 @@ public class ScaleService {
 
 	public List<Scale> findScales(String scaleDbId, String observationVariableDbId, String ontologyDbId,
 			String commonCropName, String programDbId, String externalReferenceId, String externalReferenceID,
-			String externalReferenceSource, Metadata metadata) {
+			String externalReferenceSource, Metadata metadata)
+		throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<ScaleEntity> searchQuery = new SearchQueryBuilder<ScaleEntity>(ScaleEntity.class);
 		if (observationVariableDbId != null) {
-			searchQuery = searchQuery.join("variables", "variable").appendSingle(observationVariableDbId,
+			searchQuery = searchQuery.join("variables", "variabTle").appendSingle(observationVariableDbId,
 					"*variable.id");
 		}
 		searchQuery = searchQuery.appendSingle(scaleDbId, "id").withExRefs(externalReferenceID,

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/TraitService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/TraitService.java
@@ -35,7 +35,8 @@ public class TraitService {
 
 	public List<Trait> findTraits(String traitDbId, String observationVariableDbId, String ontologyDbId,
 			String commonCropName, String programDbId, String externalReferenceId, String externalReferenceID,
-			String externalReferenceSource, Metadata metadata) {
+			String externalReferenceSource, Metadata metadata)
+		 throws BrAPIServerException {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<TraitEntity> searchQuery = new SearchQueryBuilder<TraitEntity>(TraitEntity.class);
 		if (observationVariableDbId != null) {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/TraitService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/TraitService.java
@@ -44,7 +44,7 @@ public class TraitService {
 		}
 		searchQuery = searchQuery.appendSingle(traitDbId, "id").withExRefs(externalReferenceID,
 				externalReferenceSource);
-		Page<TraitEntity> traitPage = traitRepository.findAllBySearch(searchQuery, pageReq);
+		Page<TraitEntity> traitPage = traitRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
 		PagingUtility.calculateMetaData(metadata, traitPage);
 
 		List<Trait> traits = traitPage.map(this::convertFromEntity).getContent();

--- a/src/main/resources/application.properties.template
+++ b/src/main/resources/application.properties.template
@@ -22,3 +22,12 @@ spring.mvc.dispatch-options-request=true
 security.oidc_discovery_url=https://example.com/auth/.well-known/openid-configuration
 security.enabled=true
 security.issuer_url=http://example.com/issuerurl
+
+# This should either be set in accordance with a maximum number of SQL parameters (on JOIN FETCHES of collections,
+# if there is more than one collection the IDs of each entity need to be passed through as parameters, and there is a SQL
+# maximum of 65535.  See GermplasmService.findGermplasmEntities()),
+# whatever returns in a reasonable amount of time,
+# or if you want to limit for the sake of server efficiency.
+paging.page-size.max-allowed=65000
+
+paging.page-size.default=1000


### PR DESCRIPTION
A couple of optimizations, bug fixes and workarounds have been provided to improve the performance and usability of the germplasm search endpoint.

* Hibernate was issuing a warning: `firstResult/maxResults specified with collection fetch; applying in memory` which was a big clue to why this search endpoint was performing so poorly.  Tim essentially tried to implement as vlad described [here](https://vladmihalcea.com/join-fetch-pagination-spring/#:~:text=article%20as%20well.-,Split%20the%20filtering%20and%20the%20fetching%20into%20two%20separate%20queries,-The%20previous%20solution), but there was a critical error, we passed through all of the query logic to the search query builder, which today runs paginated queries **no matter what**.  This means that while we did the grunt work of fetching the IDs separately and giving them to another query, we ended up with the same applying in memory error as before.  This code has been changed so that not only does the `SearchQueryBuilder` support non-paginated queries, there is also more support for the kind of double query that the paginated fetches require. (See GermplasmService.findGermplasmEntities()).  The performance improvement is orders of magnitude.  I went from about 4.5 seconds 100 records to about 500ms, 15 seconds on 1000 to 1 second on a dataset of 550k germs on a program.
* A workaround was created for BI to send either a null `page` and `pageSize` or neither attributed be present in the request to kick off some new logic on the germplasm search POST endpoint which will utilize the new non-paginated query that `SearchQueryBuilder` supports to return all data at once, non-paginated.  This has a breaking point, however, as at about 250k germ records per program java completely exhausts its heap trying to load all the data in entity objects and converting them to Json.  It should be noted this also isn't particularly fast, as this is a large amount of data to transmit.  125k records takes about 30 seconds on average to get back.  But this should work as a stop gap in the meantime.
* While testing both of these features I also noticed that when more pages are requested than are currently available, the system can act in peculiar and sometimes disastrous behaviors, such as fetching all records for a query instead of paginating at all, which, if performed on a large data set can completely bring the server to its knees.  To avoid this, additional logic was built into the BrAPIRepostitory impl to prevent these kinds of situations from arriving entirely by doing a max count first before fetching the query to compare the pageSize requested and the page number requested to the amount of available data.   These situations were populated up the stack for all service methods that call them to send back 400 responses when they occur with information on how to avoid these situations (this explains how many files were touched). Additional optimizatons were made here to short-circuit the query lookup code if max count produced 0 results to avoid unnecessary long-running queries.
* To totally eliminated the `Could not prepare SQL statement` error, we needed a way to completely refuse lookups that could produce more than 65k sql params, as this is the limit.  These occurred mostly in my testing when I tried to paginate germplasms large than 65k records, because in order to fetch these records we need to pass IDs of found records in inital query to later join-fetch queries.  I suppose there are other ways around this, like we could break up the queries into more queries, but the right solution feels like to incentivize the requester to actually request data from the search endpoint in a meaningful and more performant way.  That is, we have configured a way to control the maximum allowable page size for page requests on the server.  For now, it is 65k, and this applies to all entities, not just Germplasm.  Specifically for BI, this will be a problem for the cache, which we have addressed for the germplasm entity but not for other larger entities they might have, like observations and observation units.  I may revert this commit and put it somewhere else separately if it is a problem loading a cache for large datasets, or I might add to this body of code.
